### PR TITLE
Add metric_example back into index.rst in Docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,9 @@ TorchEval Tutorials
 -------------------
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Examples:
+
+   metric_example.rst
 
 QuickStart
 ===========================================


### PR DESCRIPTION
Summary: metric example was removed from index by mistake

Reviewed By: ninginthecloud

Differential Revision: D40315482

