### PR TITLE
Add py.typed to expose type annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ if __name__ == "__main__":
         python_requires=">=3.7",
         install_requires=read_requirements("requirements.txt"),
         packages=find_packages(),
+        package_data={"torcheval": ["py.typed"]},
         zip_safe=True,
         classifiers=[
             "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Summary:
https://peps.python.org/pep-0561/#packaging-type-information

> Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well. To have this file installed with the package, maintainers can use existing packaging options such as package_data in distutils, shown below.

Differential Revision: D40571362

