### PR TITLE
Add sync support for dict collections of metrics

### DIFF
--- a/torcheval/metrics/toolkit.py
+++ b/torcheval/metrics/toolkit.py
@@ -178,14 +178,16 @@ def get_synced_metric(
         tensor(0.) # Rank 0
         tensor(1.) # Rank 1
         tensor(2.) # Rank 2
-        >>>  get_synced_metric(max).compute()
-        tensor(2.) # Rank 0
-        None # Rank 1
-        None # Rank 2
-         >>>  get_synced_metric(max, recipient_rank=1).compute()
-        None # Rank 0
-        tensor(2.) # Rank 1
-        None # Rank 2
+        >>> synced_metric = get_synced_metric(max)  # by default sync metric states to Rank 0
+        >>> synced_metric.compute() if synced_metric else None
+        tensor(2.)     # Rank 0
+        None # Rank 1 -- synced_metric is None
+        None # Rank 2 -- synced_metric is None
+        >>> synced_metric = get_synced_metric(max, recipient_rank=1)
+        >>> synced_metric.compute() if synced_metric else None
+        None # Rank 0 -- synced_metric is None
+        tensor(2.)     # Rank 1
+        None # Rank 2 -- synced_metric is None
         >>>  get_synced_metric(max, recipient_rank="all").compute()
         tensor(2.) # Rank 0
         tensor(2.) # Rank 1

--- a/torcheval/metrics/toolkit.py
+++ b/torcheval/metrics/toolkit.py
@@ -6,7 +6,17 @@
 
 import logging
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    overload,
+    TypeVar,
+    Union,
+)
 
 import torch
 import torch.distributed as dist
@@ -79,6 +89,71 @@ def sync_and_compute(
     return compute_result
 
 
+def sync_and_compute_collection(
+    metrics: MutableMapping[str, Metric],
+    process_group: Optional[dist.ProcessGroup] = None,
+    recipient_rank: Union[int, Literal["all"]] = 0,
+) -> Optional[Dict[str, Any]]:
+    """
+    Sync metric states across a list of dict of metrics and returns the
+    ``metric.compute()`` result of synced metrics on recipient rank.
+    Returns ``None`` on other ranks.
+
+    Args:
+        metrics: The dict of metric objects to be synced and computed.
+        process_group: The process group on which the metric states are
+            gathered. default: ``None`` (the entire world)
+        recipient_rank: The destination rank. If string "all" is passed in,
+            then all ranks are the destination ranks.
+
+    Examples::
+
+        >>> # Assumes world_size of 3.
+        >>> # Process group initialization omitted on each rank.
+        >>> import torch
+        >>> import torch.distributed as dist
+        >>> from torcheval.metrics import Max, Min
+        >>> metrics = {"max" : Max(), "min": Min()}
+        >>> metrics["max"].update(torch.tensor(dist.get_rank())).compute()
+        tensor(0.) # Rank 0
+        tensor(1.) # Rank 1
+        tensor(2.) # Rank 2
+        >>> metrics["min"].update(torch.tensor(dist.get_rank())).compute()
+        tensor(0.) # Rank 0
+        tensor(1.) # Rank 1
+        tensor(2.) # Rank 2
+        >>> sync_and_compute_collection(metrics)
+        {"max" : tensor(2.), "min": tensor(0.)} # Rank 0
+        None # Rank 1
+        None # Rank 2
+        >>> sync_and_compute_collection(metrics, recipient_rank="all")
+        {"max" : tensor(2.), "min": tensor(0.)} # Rank 0
+        {"max" : tensor(2.), "min": tensor(0.)} # Rank 1
+        {"max" : tensor(2.), "min": tensor(0.)} # Rank 2
+    """
+    # Sync metric states to rank 0, compute and broadcast the results
+    # when recipient_rank is "all".
+    # It uses less memory than syncing metric states to all ranks,
+    # since results are usually smaller in size than metric states.
+    dst_rank = 0 if recipient_rank == "all" else recipient_rank
+
+    synced_metrics = get_synced_metric_collection(metrics, process_group, dst_rank)
+    compute_result = None
+    if synced_metrics is not None:
+        compute_result = {key: m.compute() for key, m in synced_metrics.items()}
+
+    if recipient_rank == "all":
+        obj_list = [compute_result]
+        pg = PGWrapper(process_group)
+        if pg.get_rank() == dst_rank:
+            pg.broadcast_object_list(obj_list, src=int(dst_rank))
+        else:
+            pg.broadcast_object_list(obj_list, src=int(dst_rank))
+            compute_result = obj_list[0]
+
+    return compute_result
+
+
 def get_synced_state_dict(
     metric: Metric,
     process_group: Optional[dist.ProcessGroup] = None,
@@ -117,6 +192,55 @@ def get_synced_state_dict(
     """
     synced_metric = get_synced_metric(metric, process_group, recipient_rank)
     return synced_metric.state_dict() if synced_metric else {}
+
+
+def get_synced_state_dict_collection(
+    metric_collection: MutableMapping[str, Metric],
+    process_group: Optional[dist.ProcessGroup] = None,
+    recipient_rank: Union[int, Literal["all"]] = 0,
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    """
+    Return the state dict of a collection of metrics after syncing on recipient_rank.
+    Return an None on other ranks.
+
+    Args:
+        metric_collection (Dict[str, Metric]): The metric objects to sync and get ``state_dict()``
+        process_group: The process group on which the metric states are
+            gathered. default: ``None`` (the entire world)
+        recipient_rank: The destination rank. If string "all" is passed in,
+            then all ranks are the destination ranks.
+    Returns:
+        Bundle of state dicts of for the synced metrics
+
+    Examples::
+
+        >>> # Assumes world_size of 3.
+        >>> # Process group initialization omitted on each rank.
+        >>> import torch
+        >>> import torch.distributed as dist
+        >>> from torcheval import Max, Min
+        >>> maximum = Max()
+        >>> maximum.update(torch.tensor(dist.get_rank()))
+        >>> minimum = Min()
+        >>> minimum.update(torch.tensor(dist.get_rank()))
+        >>> get_synced_state_dict({"max rank": maximum, "min rank": minimum})
+        {"max rank": {"max", tensor(2.)}, "min rank": {"min", tensor(0.)}} # Rank 0
+        None # Rank 1
+        None # Rank 2
+        >>> get_synced_state_dict({"max rank": maximum, "min rank": minimum}, recipient_rank="all")
+        {"max rank": {"max", tensor(2.)}, "min rank": {"min", tensor(0.)}} # Rank 0
+        {"max rank": {"max", tensor(2.)}, "min rank": {"min", tensor(0.)}} # Rank 1
+        {"max rank": {"max", tensor(2.)}, "min rank": {"min", tensor(0.)}} # Rank 2
+    """
+    synced_metrics = get_synced_metric_collection(
+        metric_collection,
+        process_group,
+        recipient_rank,
+    )
+
+    if synced_metrics is None:
+        return None
+    return {key: metric.state_dict() for key, metric in synced_metrics.items()}
 
 
 def clone_metric(metric: Metric) -> Metric:
@@ -193,36 +317,19 @@ def get_synced_metric(
         tensor(2.) # Rank 1
         tensor(2.) # Rank 2
     """
-    if not (isinstance(recipient_rank, int) or recipient_rank == "all"):
-        raise ValueError(
-            "``recipient_rank`` should be an integer or 'all', "
-            f"got {recipient_rank} instead."
-        )
-
     world_size = PGWrapper(process_group).get_world_size()
+    _validate_rank_and_world_size(recipient_rank, world_size)
+
     if world_size == 1:
-        log.warning(
-            "World size is 1, and metric is not synced. "
-            "``get_synced_metric()`` returns the input metric."
-        )
         return metric
     elif world_size == -1:
-        log.warning(
-            "World size is -1, and current process might not be "
-            "in the process group. ``get_synced_metric()`` returns ``None``."
-        )
         return None
-    if world_size <= 1:
-        raise RuntimeError(
-            f"Unexpected world_size {world_size} is seen when syncing metrics!"
-        )
 
     gathered_metric_list = _sync_metric_object(
         metric,
         # pyre-fixme[6]: For 2nd param expected `ProcessGroup` but got `Union[None,
         #  dist.ProcessGroup, _distributed_c10d.ProcessGroup]`.
         process_group if process_group else dist.group.WORLD,
-        # pyre-ignore[6]: expect `Union[int, Literal["all"]`, got `Union[int, str]`.
         recipient_rank,
         world_size,
     )
@@ -236,29 +343,190 @@ def get_synced_metric(
     )
 
 
+def get_synced_metric_collection(
+    metric_collection: MutableMapping[str, Metric],
+    process_group: Optional[dist.ProcessGroup] = None,
+    recipient_rank: Union[int, Literal["all"]] = 0,
+) -> Union[Optional[Dict[str, Metric]], MutableMapping[str, Metric]]:
+    """
+    Returns a dict of metric objects to the recipient_rank whose
+    internal state variables are synced across processes in the process_group.
+    Returns ``None`` on non-recipient rank.
+
+
+    The data transfer is batched to maximize efficiency.
+
+    If ``all`` is passed as recipient_rank, all ranks in the
+    ``process_group`` are considered as recipient ranks.
+
+    Args:
+        metric_collection (Dict[str, Metric]): The dict of metric objects to sync.
+        process_group (int): The process group on which the metric states are
+            gathered. default: ``None`` (the entire world)
+        recipient_rank: The destination rank. If string "all" is passed in,
+            then all ranks are the destination ranks.
+    Raises:
+        ValueError: when ``recipient_rank`` is not an integer or string
+            "all".
+
+    Examples::
+
+        >>> # Assumes world_size of 3.
+        >>> # Process group initialization omitted on each rank.
+        >>> import torch
+        >>> import torch.distributed as dist
+        >>> from torcheval.metrics import Max, Min
+        >>> metrics = {"max" : Max(), "min": Min()}
+        >>> metrics["max"].update(torch.tensor(dist.get_rank()))
+        >>> metrics["min"].update(torch.tensor(dist.get_rank()))
+        >>> synced_metrics = get_synced_metric_collection(metrics)
+
+        by default metrics sync to Rank 0
+        >>> synced_metrics["max"].compute() if synced_metrics else None
+        tensor(2.) # Rank 0
+        None       # Rank 1 -- synced_metrics is None
+        None       # Rank 2 -- synced_metrics is None
+        >>> synced_metrics["min"].compute() if synced_metrics else None
+        tensor(0.) # Rank 0
+        None       # Rank 1 -- synced_metrics is None
+        None       # Rank 2 -- synced_metrics is None
+
+        you can also sync to all ranks or choose a specific rank
+        >>> synced_metrics = get_synced_metric_collection(metrics, recipient_rank="all")
+        >>> synced_metrics["max"].compute()
+        tensor(2.) # Rank 0
+        tensor(2.) # Rank 1
+        tensor(2.) # Rank 2
+        >>> synced_metrics["min"].compute()
+        tensor(0.) # Rank 0
+        tensor(0.) # Rank 1
+        tensor(0.) # Rank 2
+    """
+    world_size = PGWrapper(process_group).get_world_size()
+    _validate_rank_and_world_size(recipient_rank, world_size)
+
+    if world_size == 1:
+        return metric_collection
+    elif world_size == -1:
+        return None
+
+    list_of_metric_collections = _sync_metric_object(
+        metric_collection,
+        # pyre-fixme[6]: For 2nd param expected `ProcessGroup` but got `Union[None,
+        #  dist.ProcessGroup, _distributed_c10d.ProcessGroup]`.
+        process_group if process_group else dist.group.WORLD,
+        recipient_rank,
+        world_size,
+    )
+
+    if list_of_metric_collections is None:
+        return None  # on non-recipient rank
+
+    elif isinstance(
+        list_of_metric_collections[0], MutableMapping
+    ):  # metric bundles are dicts.
+        synced_metric_dict: Dict[str, Metric] = {}
+        # we use rank 0 metric to clone regardless of the recipient rank
+        rank_0_dict = list_of_metric_collections[0]
+
+        for metric_key in rank_0_dict.keys():
+            base_metric = rank_0_dict[metric_key]
+            other_rank_metrics: List[Metric] = [
+                list_of_metric_collections[rank][metric_key]
+                for rank in range(1, world_size)
+            ]
+
+            synced_metric = (
+                clone_metric(base_metric)
+                .to(base_metric.device)
+                .merge_state(other_rank_metrics)
+            )
+
+            synced_metric_dict[metric_key] = synced_metric
+
+        return synced_metric_dict
+
+
+def _validate_rank_and_world_size(
+    recipient_rank: Union[int, Literal["all"]],
+    world_size: int,
+) -> None:
+    if not (isinstance(recipient_rank, int) or recipient_rank == "all"):
+        raise ValueError(
+            "``recipient_rank`` should be an integer or 'all', "
+            f"got {recipient_rank} instead."
+        )
+
+    if world_size == 1:
+        log.warning(
+            "World size is 1, and metric(s) not synced. "
+            "returning the input metric(s)."
+        )
+    elif world_size == -1:
+        log.warning(
+            "World size is -1, and current process might not be "
+            "in the process group. Returning ``None`` instead of synced metric(s)."
+        )
+    if world_size < 1:
+        raise RuntimeError(
+            f"Unexpected world_size {world_size} is seen when syncing metrics!"
+        )
+
+
+@overload
 def _sync_metric_object(
-    metric: Metric,
+    metric_data: Metric,
     process_group: dist.ProcessGroup,
     recipient_rank: Union[int, Literal["all"]],
     world_size: int,
 ) -> Optional[List[Metric]]:
-    metric._prepare_for_merge_state()
-    gathered_metric_list = (
+    ...
+
+
+@overload
+def _sync_metric_object(
+    metric_data: MutableMapping[str, Metric],
+    process_group: dist.ProcessGroup,
+    recipient_rank: Union[int, Literal["all"]],
+    world_size: int,
+) -> Optional[List[Dict[str, Metric]]]:
+    ...
+
+
+def _sync_metric_object(
+    metric_data: Union[Metric, MutableMapping[str, Metric]],
+    process_group: dist.ProcessGroup,
+    recipient_rank: Union[int, Literal["all"]],
+    world_size: int,
+) -> Union[Optional[List[Metric]], Optional[List[Dict[str, Metric]]]]:
+
+    # Prepare metrics in data package for merge
+    if isinstance(metric_data, Metric):
+        metric_data._prepare_for_merge_state()
+    else:
+        for m in metric_data.values():
+            m._prepare_for_merge_state()
+
+    # create buffer for data to land in on recipient ranks
+    gathered_data_list = (
         [None] * world_size
         if recipient_rank == "all" or dist.get_rank() == recipient_rank
         else None
     )
+
+    # sync data
     if isinstance(recipient_rank, int):
         dist.gather_object(
-            metric,
-            gathered_metric_list,
+            metric_data,
+            gathered_data_list,
             dst=recipient_rank,
             group=process_group,
         )
     elif recipient_rank == "all":
-        dist.all_gather_object(gathered_metric_list, metric, group=process_group)
-    # pyre-ignore[7]: Expected `Optional[List[Metric[typing.Any]]]` but got `Optional[List[None]]`
-    return gathered_metric_list
+        dist.all_gather_object(gathered_data_list, metric_data, group=process_group)
+    # c10d does not have type annotations.
+    # pyre-ignore: Incompatible return type [7]: Expected `Union[List[Optional[Dict[str, Metric[typing.Any]]]], List[Optional[List[Metric[typing.Any]]]], List[Optional[Metric[typing.Any]]]]` but got `Optional[List[None]]`.
+    return gathered_data_list
 
 
 def reset_metrics(metrics: _TMetrics) -> _TMetrics:


### PR DESCRIPTION
Summary: Added support for two new sync methods `sync_and_compute_collection` and `get_synced_state_dicts_collection`. These methods use only a single data transfer per sync rather than one per metric.

Differential Revision: D41674853

