### PR TITLE
Make num_labels Optional in functional version of multilabel_precision_recall_curve

### DIFF
--- a/tests/metrics/functional/classification/test_precision_recall_curve.py
+++ b/tests/metrics/functional/classification/test_precision_recall_curve.py
@@ -293,6 +293,39 @@ class TestMultilabelPrecisionRecallCurve(unittest.TestCase):
             my_compute_result, expected_result, equal_nan=True, atol=1e-8, rtol=1e-5
         )
 
+    def test_multilabel_precision_recall_curve_num_labels_None(self) -> None:
+        input = torch.tensor(
+            [
+                [0.75, 0.05, 0.35],
+                [0.45, 0.75, 0.05],
+                [0.05, 0.55, 0.75],
+                [0.05, 0.65, 0.05],
+            ]
+        )
+        target = torch.tensor([[1, 0, 0], [0, 0, 0], [0, 1, 0], [1, 1, 0]])
+        my_compute_result = multilabel_precision_recall_curve(input, target)
+        expected_result = (
+            [
+                torch.tensor([0.5, 0.5, 1.0, 1.0]),
+                torch.tensor([0.5, 0.66666667, 0.5, 0.0, 1.0]),
+                torch.tensor([0.0, 0.0, 0.0, 1.0]),
+            ],
+            [
+                torch.tensor([1.0, 0.5, 0.5, 0.0]),
+                torch.tensor([1.0, 1.0, 0.5, 0.0, 0.0]),
+                torch.tensor([1.0, 1.0, 1.0, 0.0]),
+            ],
+            [
+                torch.tensor([0.05, 0.45, 0.75]),
+                torch.tensor([0.05, 0.55, 0.65, 0.75]),
+                torch.tensor([0.05, 0.35, 0.75]),
+            ],
+        )
+        print(my_compute_result)
+        torch.testing.assert_close(
+            my_compute_result, expected_result, equal_nan=True, atol=1e-8, rtol=1e-5
+        )
+
     def test_multilabel_precision_recall_curve_invalid_input(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
@@ -301,6 +334,14 @@ class TestMultilabelPrecisionRecallCurve(unittest.TestCase):
         ):
             multilabel_precision_recall_curve(
                 torch.rand(4, 2), torch.randint(high=2, size=(4, 3)), num_labels=3
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"input should be a one-dimensional tensor, got shape torch.Size\(\[4, 3, 2\]\).",
+        ):
+            multilabel_precision_recall_curve(
+                torch.rand(4, 3, 2), torch.randint(high=2, size=(4, 3, 2)), num_labels=3
             )
 
         with self.assertRaisesRegex(

--- a/torcheval/metrics/functional/classification/precision_recall_curve.py
+++ b/torcheval/metrics/functional/classification/precision_recall_curve.py
@@ -234,7 +234,7 @@ def multilabel_precision_recall_curve(
     input: torch.Tensor,
     target: torch.Tensor,
     *,
-    num_labels: int,
+    num_labels: Optional[int] = None,
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor], List[torch.Tensor]]:
     """
     Returns precision-recall pairs and their corresponding thresholds for
@@ -247,7 +247,7 @@ def multilabel_precision_recall_curve(
         input (Tensor): Tensor of label predictions
             It should be probabilities or logits with shape of (n_sample, n_label).
         target (Tensor): Tensor of ground truth labels with shape of (n_samples, n_label).
-        num_labels (int): Number of labels.
+        num_labels (Optional): Number of labels.
 
     Return:
         a tuple of (precision: List[torch.Tensor], recall: List[torch.Tensor], thresholds: List[torch.Tensor])
@@ -272,7 +272,11 @@ def multilabel_precision_recall_curve(
         tensor([0.05, 0.55, 0.65, 0.75]),
         tensor([0.05, 0.35, 0.75])])
     """
-    if num_labels is None and input.ndim == 2:
+    if input.ndim != 2:
+        raise ValueError(
+            f"input should be a one-dimensional tensor, got shape {input.shape}."
+        )
+    if num_labels is None:
         num_labels = input.shape[1]
     _multilabel_precision_recall_curve_update(input, target, num_labels)
     return _multilabel_precision_recall_curve_compute(input, target, num_labels)
@@ -312,6 +316,11 @@ def _multilabel_precision_recall_curve_update_input_check(
         raise ValueError(
             "Expected both input.shape and target.shape to have the same shape"
             f" but got {input.shape} and {target.shape}."
+        )
+
+    if input.ndim != 2:
+        raise ValueError(
+            f"input should be a one-dimensional tensor, got shape {input.shape}."
         )
 
     if input.shape[1] != num_labels:


### PR DESCRIPTION
Summary: I make the argument `num_labels` optional for the functional version of `multilabel_precision_recall_curve`

Reviewed By: bobakfb

Differential Revision: D41856014

