### PR TITLE
Make uncalculated flops symbol consistent with others

### DIFF
--- a/tests/tools/test_module_summary.py
+++ b/tests/tools/test_module_summary.py
@@ -150,8 +150,8 @@ class ModuleSummaryTest(unittest.TestCase):
         with self.assertWarns(Warning):
             ms.num_trainable_parameters
         self.assertTrue(ms.has_uninitialized_param)
-        self.assertEqual(ms.flops_backward, -1)
-        self.assertEqual(ms.flops_forward, -1)
+        self.assertEqual(ms.flops_backward, "?")
+        self.assertEqual(ms.flops_forward, "?")
 
     def test_resnet_max_depth(self) -> None:
         """Test the behavior of max_depth on a layered model like ResNet"""


### PR DESCRIPTION
Summary: we've had -1 and "?" both present in the module summary to indicate that something was not calculated. this diff changes uncalculated flops to be "?" to match activation sizes and the forward elapsed time

Differential Revision: D42119565

