### PR TITLE
[Fix] Fix error when install from source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torchtnt>=0.0.4
 typing_extensions
+packaging


### PR DESCRIPTION
## Motivation
I got an error when following the steps in the readme to install `torcheval` from the source. 
It seems the `packaging` is an install requirement but not included in the `requirements.txt`.
```
git clone https://github.com/pytorch/torcheval
cd torcheval
pip install -r requirements.txt
python setup.py install
```

![image](https://user-images.githubusercontent.com/32220263/211972997-40baced7-86b5-4a46-abdc-8850cc1f23fb.png)

## Modification
- Add packaging in the `requirements.txt`.