### PR TITLE
refactor get random data utilities

### DIFF
--- a/tests/metrics/classification/test_auprc.py
+++ b/tests/metrics/classification/test_auprc.py
@@ -16,6 +16,7 @@ from sklearn.metrics import average_precision_score as sk_ap
 
 from torcheval.metrics import BinaryAUPRC, MulticlassAUPRC
 from torcheval.metrics.classification.auprc import MultilabelAUPRC
+from torcheval.utils.random_data import get_rand_data_binary, get_rand_data_multiclass
 from torcheval.utils.test_utils.metric_class_tester import (
     BATCH_SIZE,
     MetricClassTester,
@@ -40,15 +41,6 @@ class TestBinaryAUPRC(MetricClassTester):
             sktarget = sktargets[i, :]
             auprcs.append(np.nan_to_num(sk_ap(sktarget, skinput)))
         return torch.tensor(auprcs, device=device).to(torch.float32)
-
-    def _get_rand_inputs_binary(
-        self, num_updates: int, num_tasks: int, batch_size: int
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        input = torch.rand(size=[num_updates, num_tasks, batch_size])
-        targets = torch.randint(
-            low=0, high=2, size=[num_updates, num_tasks, batch_size]
-        )
-        return input, targets
 
     def _check_against_sklearn(
         self,
@@ -76,20 +68,20 @@ class TestBinaryAUPRC(MetricClassTester):
 
     def test_binary_auroc_class_with_good_inputs(self) -> None:
         num_tasks = 2
-        input, target = self._get_rand_inputs_binary(
-            NUM_TOTAL_UPDATES, num_tasks, BATCH_SIZE
+        input, target = get_rand_data_binary(
+            num_updates=NUM_TOTAL_UPDATES, num_tasks=num_tasks, batch_size=BATCH_SIZE
         )
         self._check_against_sklearn(input, target, num_tasks)
 
         num_tasks = 4
-        input, target = self._get_rand_inputs_binary(
-            NUM_TOTAL_UPDATES, num_tasks, BATCH_SIZE
+        input, target = get_rand_data_binary(
+            num_updates=NUM_TOTAL_UPDATES, num_tasks=num_tasks, batch_size=BATCH_SIZE
         )
         self._check_against_sklearn(input, target, num_tasks)
 
         num_tasks = 8
-        input, target = self._get_rand_inputs_binary(
-            NUM_TOTAL_UPDATES, num_tasks, BATCH_SIZE
+        input, target = get_rand_data_binary(
+            num_updates=NUM_TOTAL_UPDATES, num_tasks=num_tasks, batch_size=BATCH_SIZE
         )
         self._check_against_sklearn(input, target, num_tasks)
 
@@ -206,13 +198,6 @@ class TestMulticlassAUPRC(MetricClassTester):
             auprcs.append(np.nan_to_num(sk_ap(sktarget, skinput)))
         return torch.tensor(auprcs, device=device).to(torch.float32)
 
-    def _get_rand_inputs_multiclass(
-        self, num_updates: int, num_classes: int, batch_size: int
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        input = torch.rand(size=[num_updates, batch_size, num_classes])
-        targets = torch.randint(low=0, high=num_classes, size=[num_updates, batch_size])
-        return input, targets
-
     def _check_against_sklearn(
         self,
         input: torch.Tensor,
@@ -241,20 +226,26 @@ class TestMulticlassAUPRC(MetricClassTester):
 
     def test_multiclass_auroc_class_with_good_inputs(self) -> None:
         num_classes = 2
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 
         num_classes = 4
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 
         num_classes = 8
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 
@@ -319,8 +310,10 @@ class TestMulticlassAUPRC(MetricClassTester):
     def test_multiclass_auprc_options(self) -> None:
         # average = macro (implicit)
         num_classes = 4
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 
@@ -340,8 +333,10 @@ class TestMulticlassAUPRC(MetricClassTester):
 
         # average = macro (explicit)
         num_classes = 4
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 
@@ -361,8 +356,10 @@ class TestMulticlassAUPRC(MetricClassTester):
 
         # average = None
         num_classes = 4
-        input, target = self._get_rand_inputs_multiclass(
-            NUM_TOTAL_UPDATES, num_classes, BATCH_SIZE
+        input, target = get_rand_data_multiclass(
+            num_updates=NUM_TOTAL_UPDATES,
+            num_classes=num_classes,
+            batch_size=BATCH_SIZE,
         )
         self._check_against_sklearn(input, target, num_classes)
 

--- a/tests/utils/test_random_data.py
+++ b/tests/utils/test_random_data.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from torcheval.utils import get_rand_data_binary, get_rand_data_multiclass
+
+
+class RandomDataTest(unittest.TestCase):
+    def test_get_rand_data_binary(self) -> None:
+        input, targets = get_rand_data_binary(num_updates=2, num_tasks=5, batch_size=10)
+        self.assertEqual(input.size(), targets.size())
+
+    def test_get_rand_data_multiclass(self) -> None:
+        input, targets = get_rand_data_multiclass(
+            num_updates=2, num_classes=5, batch_size=10
+        )
+        self.assertEqual(input.size(), torch.Size([2, 10, 5]))
+        self.assertTrue(torch.all(torch.lt(targets, 5)))

--- a/torcheval/utils/__init__.py
+++ b/torcheval/utils/__init__.py
@@ -3,3 +3,10 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from torcheval.utils.random_data import get_rand_data_binary, get_rand_data_multiclass
+
+__all__ = [
+    "get_rand_data_binary",
+    "get_rand_data_multiclass",
+]

--- a/torcheval/utils/random_data.py
+++ b/torcheval/utils/random_data.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+
+
+def get_rand_data_binary(
+    *, num_updates: int, num_tasks: int, batch_size: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Generates a random binary dataset.
+
+    Args:
+        num_updates: the number of calls to update on each rank.
+        num_tasks: the number of tasks for the metric.
+        batch_size: batch size of the dataset.
+    """
+    input = torch.rand(size=[num_updates, num_tasks, batch_size])
+    targets = torch.randint(low=0, high=2, size=[num_updates, num_tasks, batch_size])
+    return input, targets
+
+
+def get_rand_data_multiclass(
+    num_updates: int, num_classes: int, batch_size: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Generates a random multiclass dataset.
+
+    Args:
+        num_updates: the number of calls to update on each rank.
+        num_classes: the number of classes for the dataset.
+        batch_size: batch size of the dataset.
+    """
+    input = torch.rand(size=[num_updates, batch_size, num_classes])
+    targets = torch.randint(low=0, high=num_classes, size=[num_updates, batch_size])
+    return input, targets


### PR DESCRIPTION
Summary:
move out the random data utilities in `test_auprc.py` into separate file
ie https://github.com/pytorch/torcheval/blob/main/tests/metrics/classification/test_auprc.py#L209-L214
and
https://github.com/pytorch/torcheval/blob/main/tests/metrics/classification/test_auprc.py#L44-L51

Overview of changes
1) Created `random_data.py` file in utils folder, added `get_rand_data_binary` and `get_rand_data_multiclass` functions to that
2) Added unit tests in `tests/utils/test_random_data.py`
3) Replaced random data functions in `test_auprc.py` to use the ones in `random_data.py`

Differential Revision: D43065841

