### PR TITLE
add banner for meta internal docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx==5.0.1
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/source/_static/css/torcheval.css
+++ b/docs/source/_static/css/torcheval.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#redirect-banner {
+    border-bottom: 1px solid #e2e2e2;
+}
+#redirect-banner > p {
+    margin: 0.8rem;
+    text-align: center;
+}

--- a/docs/source/_static/js/torcheval.js
+++ b/docs/source/_static/js/torcheval.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const NETWORK_TEST_URL = 'https://staticdocs.thefacebook.com/ping';
+fetch(NETWORK_TEST_URL).then(() => {
+    $("#redirect-banner").prependTo("body").show();
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ else:
 html_context = {"fbcode": FBCODE}
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+templates_path = ["templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -79,19 +79,40 @@ exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+html_theme_options = {
+    "display_version": True,
+}
+html_css_files = [
+    "css/torcheval.css",
+]
+html_js_files = [
+    "js/torcheval.js",
+]
+
+
+def setup(app):
+    # NOTE: in Sphinx 1.8+ `html_css_files` is an official configuration value
+    # and can be moved outside of this function (and the setup(app) function
+    # can be deleted).
+
+    # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is
+    # `add_stylesheet` (deprecated in 1.8).
+    add_css = getattr(
+        app, "add_css_file", getattr(app, "add_stylesheet", None)
+    )  # noqa B009
+    for css_file in html_css_files:
+        add_css(css_file)
+
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
 html_theme = "pytorch_sphinx_theme"
 html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
-html_theme_options = {
-    "display_version": True,
-}
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
 
 # where to find external docs
 intersphinx_mapping = {

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -1,0 +1,12 @@
+{% extends "!layout.html" %}
+
+{%- block extrabody %}
+  {% if not fbcode %}
+    <div id="redirect-banner" style="display: none">
+      <p>
+        This is the public documentation. There is internal documentation for Meta employees at
+        <a href="https://www.internalfb.com/intern/staticdocs/torcheval/">https://www.internalfb.com/intern/staticdocs/torcheval/</a>
+      </p>
+    </div>
+  {% endif %}
+{%- endblock %}


### PR DESCRIPTION
Summary: Add banner to redirect meta employees to internal torcheval docs

Differential Revision: D43070400

