### PR TITLE
in classification metrics docstrings, add links to other similar metrics

### DIFF
--- a/torcheval/metrics/classification/accuracy.py
+++ b/torcheval/metrics/classification/accuracy.py
@@ -33,6 +33,7 @@ class MulticlassAccuracy(Metric[torch.Tensor]):
     """
     Compute accuracy score, which is the frequency of input matching target.
     Its functional version is :func:`torcheval.metrics.functional.multiclass_accuracy`.
+    See also :class:`BinaryAccuracy <BinaryAccuracy>`, :class:`MultilabelAccuracy <MultilabelAccuracy>`, :class:`TopKMultilabelAccuracy <TopKMultilabelAccuracy>`
 
     Args:
         average (str, Optional)
@@ -148,6 +149,7 @@ class BinaryAccuracy(MulticlassAccuracy):
     """
     Compute binary accuracy score, which is the frequency of input matching target.
     Its functional version is :func:`torcheval.metrics.functional.binary_accuracy`.
+    See also :class:`MulticlassAccuracy <MulticlassAccuracy>`, :class:`MultilabelAccuracy <MultilabelAccuracy>`, :class:`TopKMultilabelAccuracy <TopKMultilabelAccuracy>`
 
     Args:
 
@@ -208,6 +210,7 @@ class MultilabelAccuracy(MulticlassAccuracy):
     """
     Compute multilabel accuracy score, which is the frequency of input matching target.
     Its functional version is :func:`torcheval.metrics.functional.multilabel_accuracy`.
+    See also :class:`MulticlassAccuracy <MulticlassAccuracy>`, :class:`BinaryAccuracy <BinaryAccuracy>`, :class:`TopKMultilabelAccuracy <TopKMultilabelAccuracy>`
 
     Args:
         threshold (float, Optional): Threshold for converting input into predicted labels for each sample.
@@ -306,6 +309,7 @@ class TopKMultilabelAccuracy(MulticlassAccuracy):
     """
     Compute multilabel accuracy score, which is the frequency of the top k label predicted matching target.
     Its functional version is :func:`torcheval.metrics.functional.topk_multilabel_accuracy`.
+    See also :class:`MulticlassAccuracy <MulticlassAccuracy>`, :class:`BinaryAccuracy <BinaryAccuracy>`, :class:`MultilabelAccuracy <MultilabelAccuracy>`
 
     Args:
         criteria (string):

--- a/torcheval/metrics/classification/auprc.py
+++ b/torcheval/metrics/classification/auprc.py
@@ -43,6 +43,7 @@ class BinaryAUPRC(Metric[torch.Tensor]):
     instance of binary auprc.
 
     The functional version of this metric is :func:`torcheval.metrics.functional.binary_auprc`.
+    See also :class:`MulticlassAUPRC <MulticlassAUPRC>`, :class:`MultilabelAUPRC <MultilabelAUPRC>`
 
     Args:
         num_tasks (int): Number of tasks that need BinaryAUPRC calculation. Default value
@@ -170,6 +171,7 @@ class MulticlassAUPRC(Metric[torch.Tensor]):
     See examples below for more details on the connection between Multiclass and Binary AUPRC.
 
     The functional version of this metric is :func:`torcheval.metrics.functional.multiclass_auprc`.
+    See also :class:`BinaryAUPRC <BinaryAUPRC>`, :class:`MultilabelAUPRC <MultilabelAUPRC>`
 
     Args:
         num_classes (int): Number of classes.
@@ -310,6 +312,7 @@ class MultilabelAUPRC(Metric[torch.Tensor]):
     See examples below for more details on the connection between Multilabel and Binary AUPRC.
 
     The functional version of this metric is :func:`torcheval.metrics.functional.multilabel_auprc`.
+    See also :class:`BinaryAUPRC <BinaryAUPRC>`, :class:`MulticlassAUPRC <MulticlassAUPRC>`
 
     Args:
         num_labels (int): Number of labels.

--- a/torcheval/metrics/classification/auroc.py
+++ b/torcheval/metrics/classification/auroc.py
@@ -40,6 +40,7 @@ class BinaryAUROC(Metric[torch.Tensor]):
     Multiple tasks are supported for Binary AUROC. A two-dimensional vector can given for the predicted values (inputs) and targets. This gives equivalent results to having one BinaryAUROC object for each row.
 
     Its functional version is :func:`torcheval.metrics.functional.binary_auroc`.
+    See also :class:`MulticlassAUROC <MulticlassAUROC>`
 
     Examples::
 
@@ -162,6 +163,7 @@ class MulticlassAUROC(Metric[torch.Tensor]):
     See examples below for more details on the connection between Multiclass and Binary AUROC.
 
     The functional version of this metric is :func:`torcheval.metrics.functional.multiclass_auroc`.
+    See also :class:`BinaryAUROC <BinaryAUROC>`
 
     Args:
         num_classes (int): Number of classes.

--- a/torcheval/metrics/classification/binned_auroc.py
+++ b/torcheval/metrics/classification/binned_auroc.py
@@ -37,6 +37,7 @@ class BinaryBinnedAUROC(Metric[Tuple[torch.Tensor, torch.Tensor]]):
         num_tasks (int):  Number of tasks that need binary_binned_auroc calculation. Default value
                     is 1. binary_binned_auroc for each task will be calculated independently.
         threshold: A integeter representing number of bins, a list of thresholds, or a tensor of thresholds.
+    See also :class:`MulticlassBinnedAUROC <MulticlassBinnedAUROC>`
 
 
     Examples::
@@ -150,6 +151,7 @@ class MulticlassBinnedAUROC(Metric[Tuple[torch.Tensor, torch.Tensor]]):
     """
     Compute AUROC, which is the area under the ROC Curve, for multiclass classification.
     Its functional version is :func:`torcheval.metrics.functional.multiclass_binned_auroc`.
+    See also :class:`BinaryBinnedAUROC <BinaryBinnedAUROC>`
 
     Args:
         num_classes (int): Number of classes.

--- a/torcheval/metrics/classification/binned_precision_recall_curve.py
+++ b/torcheval/metrics/classification/binned_precision_recall_curve.py
@@ -30,6 +30,7 @@ class BinaryBinnedPrecisionRecallCurve(
     """
     Compute precision recall curve with given thresholds.
     Its functional version is :func:`torcheval.metrics.functional.binary_binned_precision_recall_curve`.
+    See also :class:`MulticlassBinnedPrecisionRecallCurve <MulticlassBinnedPrecisionRecallCurve>`
 
     Args:
         threshold (Union[int, List[float], torch.Tensor], Optional):
@@ -135,6 +136,7 @@ class MulticlassBinnedPrecisionRecallCurve(
     """
     Compute precision recall curve with given thresholds.
     Its functional version is :func:`torcheval.metrics.functional.multiclass_binned_precision_recall_curve`.
+    See also :class:`BinaryBinnedPrecisionRecallCurve <BinaryBinnedPrecisionRecallCurve>`
 
     Args:
         num_classes (int):

--- a/torcheval/metrics/classification/confusion_matrix.py
+++ b/torcheval/metrics/classification/confusion_matrix.py
@@ -26,6 +26,7 @@ TBinaryConfusionMatrix = TypeVar("TBinaryConfusionMatrix")
 class MulticlassConfusionMatrix(Metric[torch.Tensor]):
     """
     Compute multi-class confusion matrix, a matrix of dimension num_classes x num_classes where each element at position `(i,j)` is the number of examples with true class `i` that were predicted to be class `j`.
+    See also :class:`BinaryConfusionMatrix <BinaryConfusionMatrix>`
 
     Args:
         input (Tensor): Tensor of label predictions.
@@ -212,6 +213,7 @@ class MulticlassConfusionMatrix(Metric[torch.Tensor]):
 class BinaryConfusionMatrix(MulticlassConfusionMatrix):
     """
     Compute binary confusion matrix, a 2 by 2 tensor with counts ( (true positive, false negative) , (false positive, true negative) )
+    See also :class:`MulticlassConfusionMatrix <MulticlassConfusionMatrix>`
 
     Args:
         input (Tensor): Tensor of label predictions with shape of (n_sample,).

--- a/torcheval/metrics/classification/f1_score.py
+++ b/torcheval/metrics/classification/f1_score.py
@@ -29,6 +29,7 @@ class MulticlassF1Score(Metric[torch.Tensor]):
     We convert NaN to zero when f1 score is NaN. This happens when either precision
     or recall is NaN or when both precision and recall are zero.
     Its functional version is :func:`torcheval.metrics.functional.multi_class_f1_score`.
+    See also :class:`BinaryF1Score <BinaryF1Score>`
 
     Args:
         num_classes (int):
@@ -160,6 +161,7 @@ class BinaryF1Score(MulticlassF1Score):
     We convert NaN to zero when f1 score is NaN. This happens when either precision
     or recall is NaN or when both precision and recall are zero.
     Its functional version is :func:``torcheval.metrics.functional.binary_f1_score``.
+    See also :class:`MulticlassF1Score <MulticlassF1Score>`
 
     Args:
         threshold (float, optional) : Threshold for converting input into predicted labels for each sample.

--- a/torcheval/metrics/classification/precision.py
+++ b/torcheval/metrics/classification/precision.py
@@ -28,6 +28,7 @@ class MulticlassPrecision(Metric[torch.Tensor]):
     true positives and false positives.
     Its functional version is :func:`torcheval.metrics.functional.multiclass_precision`.
     We cast NaNs to 0 in case some classes have zero instances in the predictions.
+    See also :class:`BinaryPrecision <BinaryPrecision>`
 
     Args:
         num_classes (int):
@@ -159,6 +160,7 @@ class BinaryPrecision(MulticlassPrecision):
     Its functional version is :func:`torcheval.metrics.functional.binary_precision`.
     We cast NaNs to 0 when classes have zero positive instances in prediction labels
     (when TP + FP = 0).
+    See also :class:`MulticlassPrecision <MulticlassPrecision>`
 
     Args:
         threshold (float, default = 0.5): Threshold for converting input into predicted labels for each sample.

--- a/torcheval/metrics/classification/precision_recall_curve.py
+++ b/torcheval/metrics/classification/precision_recall_curve.py
@@ -38,6 +38,7 @@ class BinaryPrecisionRecallCurve(
     its recall values are set to 1.0.
 
     Its functional version is :func:`torcheval.metrics.functional.binary_precision_recall_curve`.
+    See also :class:`MulticlassPrecisionRecallCurve <MulticlassPrecisionRecallCurve>`, :class:`MultilabelPrecisionRecallCurve <MultilabelPrecisionRecallCurve>`
 
         >>> import torch
         >>> from torcheval.metrics import BinaryPrecisionRecallCurve
@@ -127,6 +128,7 @@ class MulticlassPrecisionRecallCurve(
     tensor, its recall values are set to 1.0.
 
     Its class version is :func:`torcheval.metrics.functional.multiclass_precision_recall_curve`.
+    See also :class:`BinaryPrecisionRecallCurve <BinaryPrecisionRecallCurve>`, :class:`MultilabelPrecisionRecallCurve <MultilabelPrecisionRecallCurve>`
 
     Args:
         num_classes (int, Optional):
@@ -235,6 +237,7 @@ class MultilabelPrecisionRecallCurve(
     in the target tensor, its recall values are set to 1.0.
 
     Its class version is :func:`torcheval.metrics.functional.multilabel_precision_recall_curve`.
+    See also :class:`BinaryPrecisionRecallCurve <BinaryPrecisionRecallCurve>`, :class:`MulticlassPrecisionRecallCurve <MulticlassPrecisionRecallCurve>`
 
     Args:
         num_labels (int): Number of labels.

--- a/torcheval/metrics/classification/recall.py
+++ b/torcheval/metrics/classification/recall.py
@@ -30,6 +30,7 @@ class BinaryRecall(Metric[torch.Tensor]):
     Its functional version is :func:`torcheval.metrics.functional.binary_recall`.
     We cast NaNs to 0 when classes have zero instances in the ground-truth labels
     (when TP + FN = 0).
+    See also :class:`MulticlassRecall <MulticlassRecall>`
 
     Args:
         threshold (float, default 0.5): Threshold for converting input into predicted labels for each sample.
@@ -117,6 +118,7 @@ class MulticlassRecall(Metric[torch.Tensor]):
     Its functional version is :func:`torcheval.metrics.functional.multiclass_recall`.
     We cast NaNs to 0 when classes have zero instances in the ground-truth labels
     (when TP + FN = 0).
+    See also :class:`BinaryRecall <BinaryRecall>`
 
     Args:
         num_classes (int):

--- a/torcheval/metrics/classification/recall_at_fixed_precision.py
+++ b/torcheval/metrics/classification/recall_at_fixed_precision.py
@@ -32,6 +32,7 @@ class BinaryRecallAtFixedPrecision(Metric[Tuple[torch.Tensor, torch.Tensor]]):
     for binary classification tasks.
 
     Its functional version is :func:`torcheval.metrics.functional.binary_recall_at_fixed_precision`.
+    See also :class:`MultilabelRecallAtFixedPrecision <MultilabelRecallAtFixedPrecision>`
 
     Args:
         min_precision (float): Minimum precision threshold
@@ -111,6 +112,7 @@ class MultilabelRecallAtFixedPrecision(
     equivalent to _binary_recall_at_fixed_precision_compute in BinaryRecallAtFixedPrecision.
 
     Its functional version is :func:`torcheval.metrics.functional.multilabel_recall_at_fixed_precision`.
+    See also :class:`BinaryRecallAtFixedPrecision <BinaryRecallAtFixedPrecision>`
 
     Args:
         num_labels (int): Number of labels

--- a/torcheval/metrics/functional/classification/accuracy.py
+++ b/torcheval/metrics/functional/classification/accuracy.py
@@ -19,6 +19,7 @@ def binary_accuracy(
     """
     Compute binary accuracy score, which is the frequency of input matching target.
     Its class version is :obj:`torcheval.metrics.BinaryAccuracy`.
+    See also :func:`multiclass_accuracy <torcheval.metrics.functional.multiclass_accuracy>`, :func:`multilabel_accuracy <torcheval.metrics.functional.multilabel_accuracy>`, :func:`topk_multilabel_accuracy <torcheval.metrics.functional.topk_multilabel_accuracy>`
 
     Args:
         input (Tensor): Tensor of label predictions with shape of (n_sample,).
@@ -57,6 +58,7 @@ def multiclass_accuracy(
     """
     Compute accuracy score, which is the frequency of input matching target.
     Its class version is ``torcheval.metrics.MultiClassAccuracy``.
+    See also :func:`binary_accuracy <torcheval.metrics.functional.binary_accuracy>`, :func:`multilabel_accuracy <torcheval.metrics.functional.multilabel_accuracy>`, :func:`topk_multilabel_accuracy <torcheval.metrics.functional.topk_multilabel_accuracy>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -114,6 +116,7 @@ def multilabel_accuracy(
     """
     Compute multilabel accuracy score, which is the frequency of input matching target.
     Its class version is ``torcheval.metrics.MultilabelAccuracy``.
+    See also :func:`binary_accuracy <torcheval.metrics.functional.binary_accuracy>`, :func:`multiclass_accuracy <torcheval.metrics.functional.multiclass_accuracy>`, :func:`topk_multilabel_accuracy <torcheval.metrics.functional.topk_multilabel_accuracy>`
 
     Args:
         input (Tensor): Tensor of label predictions with shape of (n_sample, n_class).
@@ -184,6 +187,7 @@ def topk_multilabel_accuracy(
     """
     Compute multilabel accuracy score, which is the frequency of the top k label predicted matching target.
     Its class version is ``torcheval.metrics.TopKMultilabelAccuracy``.
+    See also :func:`binary_accuracy <torcheval.metrics.functional.binary_accuracy>`, :func:`multiclass_accuracy <torcheval.metrics.functional.multiclass_accuracy>`, :func:`multilabel_accuracy <torcheval.metrics.functional.multilabel_accuracy>`
 
     Args:
         input (Tensor): Tensor of logits/probabilities with shape of (n_sample, n_class).

--- a/torcheval/metrics/functional/classification/auprc.py
+++ b/torcheval/metrics/functional/classification/auprc.py
@@ -33,6 +33,8 @@ def binary_auprc(
     This function returns the area under that graph. If the area is near one, the model supports a threshold which correctly identifies
     a high percentage of true positives while also rejecting enough false examples so that most of the true predictions are true positives.
 
+    See also :func:`multiclass_auprc <torcheval.metrics.functional.multiclass_auprc>`, :func:`multilabel_auprc <torcheval.metrics.functional.multilabel_auprc>`
+
     Args:
         input (Tensor): Tensor of label predictions
             It should be predicted label, probabilities or logits with shape of (num_tasks, n_sample) or (n_sample, ).
@@ -93,6 +95,8 @@ def multiclass_auprc(
 
     1. the input is transposed, in binary classification examples are associated with columns, whereas they are associated with rows in multiclass classification.
     2. the `target` is translated from the form [1,0,1] to the form [[0,1,0], [1,0,1]]
+
+    See also :func:`binary_auprc <torcheval.metrics.functional.binary_auprc>`, :func:`multilabel_auprc <torcheval.metrics.functional.multilabel_auprc>`
 
     Args:
         input (Tensor): 2 dimensional tensor of label predictions
@@ -175,6 +179,7 @@ def multilabel_auprc(
     2. the `target` is transposed for the same reason
 
     See examples below for more details on the connection between Multilabel and Binary AUPRC.
+    See also :func:`binary_auprc <torcheval.metrics.functional.binary_auprc>`, :func:`multiclass_auprc <torcheval.metrics.functional.multiclass_auprc>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/auroc.py
+++ b/torcheval/metrics/functional/classification/auroc.py
@@ -33,6 +33,7 @@ def binary_auroc(
     """
     Compute AUROC, which is the area under the ROC Curve, for binary classification.
     Its class version is ``torcheval.metrics.BinaryAUROC``.
+    See also :func:`multiclass_auroc <torcheval.metrics.functional.multiclass_auroc>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -81,6 +82,7 @@ def multiclass_auroc(
     """
     Compute AUROC, which is the area under the ROC Curve, for multiclass classification.
     Its class version is :obj:`torcheval.metrics.MulticlassAUROC`.
+    See also :func:`binary_auroc <torcheval.metrics.functional.binary_auroc>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/binned_auroc.py
+++ b/torcheval/metrics/functional/classification/binned_auroc.py
@@ -24,6 +24,7 @@ def binary_binned_auroc(
     """
     Compute AUROC, which is the area under the ROC Curve, for binary classification.
     Its class version is ``torcheval.metrics.BinaryBinnedAUROC``.
+    See also :func:`multiclass_binned_auroc <torcheval.metrics.functional.multiclass_binned_auroc>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -144,6 +145,7 @@ def multiclass_binned_auroc(
     """
     Compute AUROC, which is the area under the ROC Curve, for multiclass classification.
     Its class version is :obj:`torcheval.metrics.MulticlassAUROC`.
+    See also :func:`binary_binned_auroc <torcheval.metrics.functional.binary_binned_auroc>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/binned_precision_recall_curve.py
+++ b/torcheval/metrics/functional/classification/binned_precision_recall_curve.py
@@ -25,6 +25,7 @@ def binary_binned_precision_recall_curve(
     """
     Compute precision recall curve with given thresholds.
     Its class version is ``torcheval.metrics.BinaryBinnedPrecisionRecallCurve``.
+    See also :func:`multiclass_binned_precision_recall_curve <torcheval.metrics.functional.multiclass_binned_precision_recall_curve>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -121,6 +122,7 @@ def multiclass_binned_precision_recall_curve(
     """
     Compute precision recall curve with given thresholds.
     Its class version is ``torcheval.metrics.MulticlassBinnedPrecisionRecallCurve``.
+    See also :func:`binary_binned_precision_recall_curve <torcheval.metrics.functional.binary_binned_precision_recall_curve>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/confusion_matrix.py
+++ b/torcheval/metrics/functional/classification/confusion_matrix.py
@@ -21,6 +21,7 @@ def binary_confusion_matrix(
 ) -> torch.Tensor:
     """
     Compute binary confusion matrix, a 2 by 2 tensor with counts ( (true positive, false negative) , (false positive, true negative) )
+    See also :func:`multiclass_confusion_matrix <torcheval.metrics.functional.multiclass_confusion_matrix>`
 
     Args:
         input (Tensor): Tensor of label predictions with shape of (n_sample,).
@@ -74,6 +75,7 @@ def multiclass_confusion_matrix(
 ) -> torch.Tensor:
     """
     Compute multi-class confusion matrix, a matrix of dimension num_classes x num_classes where each element at position `(i,j)` is the number of examples with true class `i` that were predicted to be class `j`.
+    See also :func:`binary_confusion_matrix <torcheval.metrics.functional.binary_confusion_matrix>`
 
     Args:
         input (Tensor): Tensor of label predictions.

--- a/torcheval/metrics/functional/classification/f1_score.py
+++ b/torcheval/metrics/functional/classification/f1_score.py
@@ -21,6 +21,7 @@ def binary_f1_score(
 ) -> torch.Tensor:
     """
     Compute binary f1 score, the harmonic mean of precision and recall.
+    See also :func:`multiclass_f1_score <torcheval.metrics.functional.multiclass_f1_score>`
 
     Args:
         input (Tensor): Tensor of label predictions with shape of (n_sample,).
@@ -61,6 +62,7 @@ def multiclass_f1_score(
     We convert NaN to zero when f1 score is NaN. This happens when either precision
     or recall is NaN or when both precision and recall are zero.
     Its class version is ``torcheval.metrics.MultiClassF1Score``.
+    See also :func:`binary_f1_score <torcheval.metrics.functional.binary_f1_score>`
 
     Args:
         input (Tensor): Tensor of label predictions.

--- a/torcheval/metrics/functional/classification/precision.py
+++ b/torcheval/metrics/functional/classification/precision.py
@@ -24,6 +24,7 @@ def binary_precision(
     Compute precision score for binary classification class, which is calculated as the ratio between the number of
     true positives (TP) and the total number of predicted positives (TP + FP).
     Its class version is ``torcheval.metrics.BinaryPrecision``.
+    See also :func:`multiclass_precision <torcheval.metrics.functional.multiclass_precision>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -63,6 +64,7 @@ def multiclass_precision(
     Compute precision score, which is the ratio of the true positives (TP) and the
     total number of points classified as positives (TP + FP).
     Its class version is ``torcheval.metrics.MultiClassPrecision``.
+    See also :func:`binary_precision <torcheval.metrics.functional.binary_precision>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/precision_recall_curve.py
+++ b/torcheval/metrics/functional/classification/precision_recall_curve.py
@@ -26,6 +26,7 @@ def binary_precision_recall_curve(
     its recall values are set to 1.0.
 
     Its class version is ``torcheval.metrics.BinaryPrecisionRecallCurve``.
+    See also :func:`multiclass_precision_recall_curve <torcheval.metrics.functional.multiclass_precision_recall_curve>`, :func:`multilabel_precision_recall_curve <torcheval.metrics.functional.multilabel_precision_recall_curve>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -103,6 +104,7 @@ def multiclass_precision_recall_curve(
     tensor, its recall values are set to 1.0.
 
     Its class version is ``torcheval.metrics.MulticlassPrecisionRecallCurve``.
+    See also :func:`binary_precision_recall_curve <torcheval.metrics.functional.binary_precision_recall_curve>`, :func:`multilabel_precision_recall_curve <torcheval.metrics.functional.multilabel_precision_recall_curve>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -242,6 +244,7 @@ def multilabel_precision_recall_curve(
     in the target tensor, its recall values are set to 1.0.
 
     Its class version is ``torcheval.metrics.MultilabelPrecisionRecallCurve``.
+    See also :func:`binary_precision_recall_curve <torcheval.metrics.functional.binary_precision_recall_curve>`, :func:`multiclass_precision_recall_curve <torcheval.metrics.functional.multiclass_precision_recall_curve>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/recall.py
+++ b/torcheval/metrics/functional/classification/recall.py
@@ -21,6 +21,7 @@ def binary_recall(
     Compute recall score for binary classification class, which is calculated as the ratio between the number of
     true positives (TP) and the total number of actual positives (TP + FN).
     Its class version is ``torcheval.metrics.BinaryRecall``.
+    See also :func:`multiclass_recall <torcheval.metrics.functional.multiclass_recall>`
 
     Args:
         input (Tensor): Tensor of the predicted labels/logits/probabilities, with shape of (n_sample, ).
@@ -104,6 +105,7 @@ def multiclass_recall(
     Compute recall score, which is calculated as the ratio between the number of
     true positives (TP) and the total number of actual positives (TP + FN).
     Its class version is ``torcheval.metrics.MultiClassRecall``.
+    See also :func:`binary_recall <torcheval.metrics.functional.binary_recall>`
 
     Args:
         input (Tensor): Tensor of label predictions

--- a/torcheval/metrics/functional/classification/recall_at_fixed_precision.py
+++ b/torcheval/metrics/functional/classification/recall_at_fixed_precision.py
@@ -29,6 +29,7 @@ def binary_recall_at_fixed_precision(
     for binary classification tasks.
 
     Its class version is ``torcheval.metrics.BinaryRecallAtFixedPrecision``.
+    See also :func:`multilabel_recall_at_fixed_precision <torcheval.metrics.functional.multilabel_recall_at_fixed_precision>`
 
     Args:
         input (Tensor): Tensor of label predictions
@@ -83,6 +84,7 @@ def multilabel_recall_at_fixed_precision(
     equivalent to _binary_recall_at_fixed_precision_compute in binary_recall_at_fixed_precision.
 
     Its class version is ``torcheval.metrics.MultilabelRecallAtFixedPrecision``.
+    See also :func:`binary_recall_at_fixed_precision <torcheval.metrics.functional.binary_recall_at_fixed_precision>`
 
     Args:
         input (Tensor): Tensor of label predictions


### PR DESCRIPTION
Summary: for each file in folder torcheval/metrics/classification, I made a link in the docstrings of every class to the other classes of this file (and same for functions in torcheval/functional/classification).

Reviewed By: bobakfb

Differential Revision: D44547541

