### PR TITLE
Fix error in BinaryPrecision computation

### DIFF
--- a/torcheval/metrics/functional/classification/precision.py
+++ b/torcheval/metrics/functional/classification/precision.py
@@ -227,8 +227,8 @@ def _binary_precision_update(
     _binary_precision_update_input_check(input, target)
 
     input = torch.where(input < threshold, 0, 1)
-    num_tp = (input & target).sum()
-    num_fp = (input & (~target)).sum()
+    num_tp = (input * target).sum(dim=-1)
+    num_fp = input.sum(dim=-1) - num_tp
 
     num_label = torch.tensor(0.0)
 


### PR DESCRIPTION
Summary:
Addressing gh issue https://github.com/pytorch/torcheval/issues/146

Binary Precision doesn't work when target is a float tensor.

Differential Revision: D45261417

