### PR TITLE
Fixed docstring of FlopTensorDispatchMode

### DIFF
--- a/torcheval/tools/flops.py
+++ b/torcheval/tools/flops.py
@@ -185,7 +185,7 @@ class FlopTensorDispatchMode(TorchDispatchMode):
         >>> from torcheval.tools.flops import FlopTensorDispatchMode
 
         >>> module = models.resnet18()
-        >>> inp = torch.randn(1, 3, 224, 224)
+        >>> module_input = torch.randn(1, 3, 224, 224)
         >>> with FlopTensorDispatchMode(module) as ftdm:
         >>>     # count forward flops
         >>>     res = module(module_input).mean()


### PR DESCRIPTION
Summary:
Small variable name error in the docstring of FlopTensorDispatchMode.

Test plan:
N/A, very minor doc change

Fixes #152 

