### PR TITLE
update throughput metric to use float state

### DIFF
--- a/tests/metrics/aggregation/test_cat.py
+++ b/tests/metrics/aggregation/test_cat.py
@@ -21,7 +21,7 @@ class TestCat(MetricClassTester):
     ) -> None:
         self.run_class_implementation_tests(
             metric=Cat(),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": input_val_tensors},
             compute_result=torch.cat(input_val_tensors, dim=dim),
         )
@@ -46,7 +46,7 @@ class TestCat(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=Cat(),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": update_inputs},
             compute_result=torch.cat(update_inputs, dim=0),
             num_total_updates=4,
@@ -63,7 +63,7 @@ class TestCat(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=Cat(dim=1),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": update_inputs},
             compute_result=torch.cat(update_inputs, dim=1),
             num_total_updates=4,
@@ -80,7 +80,7 @@ class TestCat(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=Cat(dim=-1),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": update_inputs},
             compute_result=torch.cat(update_inputs, dim=-1),
             num_total_updates=4,
@@ -97,7 +97,7 @@ class TestCat(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=Cat(),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": update_inputs},
             compute_result=torch.cat(update_inputs, dim=0),
             num_total_updates=4,
@@ -128,7 +128,7 @@ class TestCat(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=Cat(),
-            state_names={"inputs"},
+            state_names={"dim", "inputs"},
             update_kwargs={"input": update_inputs},
             compute_result=torch.cat(update_inputs, dim=0),
             num_total_updates=4,

--- a/tests/metrics/aggregation/test_throughput.py
+++ b/tests/metrics/aggregation/test_throughput.py
@@ -7,7 +7,6 @@
 import random
 from typing import List
 
-import torch
 from torcheval.metrics import Throughput
 from torcheval.utils.test_utils.metric_class_tester import (
     MetricClassTester,
@@ -23,23 +22,23 @@ class TestThroughput(MetricClassTester):
         elapsed_time_sec: List[float],
     ) -> None:
         num_individual_update = NUM_TOTAL_UPDATES // NUM_PROCESSES
-        expected_num_total = torch.sum(torch.tensor(num_processed)).to(torch.float64)
-        max_elapsed_time_sec = torch.max(
-            torch.tensor(
-                [
-                    sum(
-                        elapsed_time_sec[
-                            i * num_individual_update : (i + 1) * num_individual_update
-                        ]
-                    )
-                    for i in range(NUM_PROCESSES)
-                ]
-            )
+        expected_num_total = sum(num_processed)
+        max_elapsed_time_sec = max(
+            [
+                sum(
+                    elapsed_time_sec[
+                        i * num_individual_update : (i + 1) * num_individual_update
+                    ]
+                )
+                for i in range(NUM_PROCESSES)
+            ]
         )
-        total_elapsed_time_sec = torch.sum(torch.tensor(elapsed_time_sec))
+        total_elapsed_time_sec = sum(elapsed_time_sec)
 
-        expected_compute_result = expected_num_total / total_elapsed_time_sec
-        expected_merge_and_compute_result = expected_num_total / max_elapsed_time_sec
+        expected_compute_result = (1.0 * expected_num_total) / total_elapsed_time_sec
+        expected_merge_and_compute_result = (
+            1.0 * expected_num_total
+        ) / max_elapsed_time_sec
         self.run_class_implementation_tests(
             metric=Throughput(),
             state_names={"num_total", "elapsed_time_sec"},
@@ -79,4 +78,4 @@ class TestThroughput(MetricClassTester):
 
     def test_throughput_class_compute_without_update(self) -> None:
         metric = Throughput()
-        self.assertEqual(metric.compute(), torch.tensor(0.0, dtype=torch.float64))
+        self.assertEqual(metric.compute(), 0.0)

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -88,11 +88,6 @@ class MetricBaseClassTest(unittest.TestCase):
         ):
             # pyre-ignore[6]: Incompatible parameter type
             metric._add_state("x2", [[torch.tensor(0.0)]])
-        with self.assertRaisesRegex(
-            TypeError, r"The value of state variable must be.*Get x3=0.0 instead."
-        ):
-            # pyre-ignore[6]: Incompatible parameter type
-            metric._add_state("x3", 0.0)
 
     def test_reset_state_tensor(self) -> None:
         metric = DummySumMetric()
@@ -257,7 +252,7 @@ class MetricBaseClassTest(unittest.TestCase):
 
     def test_state_dict_destination_prefix_wrong_state_value(self) -> None:
         metric = DummySumMetric()
-        metric.sum = 1.0
+        metric.sum = "1.0"
 
         with self.assertRaisesRegex(
             TypeError, r"The value of state variable must be.*Get sum=1.0 instead."
@@ -300,7 +295,7 @@ class MetricBaseClassTest(unittest.TestCase):
         with self.assertRaisesRegex(
             TypeError, r"The value of state variable must be.*Get sum=1.0 instead."
         ):
-            metric.load_state_dict({"sum": 1.0})
+            metric.load_state_dict({"sum": "1.0"})
 
     #  `torch.cuda.is_available()` to decorator factory `unittest.skipUnless`.
     @unittest.skipUnless(
@@ -347,11 +342,3 @@ class MetricBaseClassTest(unittest.TestCase):
         torch.testing.assert_close(metric.x, {"doc1": torch.tensor(1.0, device="cpu")})
         metric.to("cuda")
         torch.testing.assert_close(metric.x, {"doc1": torch.tensor(1.0, device="cuda")})
-
-    def test_to_device_invalid_state(self) -> None:
-        metric = DummySumMetric()
-        metric.sum = 1.0
-        with self.assertRaisesRegex(
-            TypeError, r"The value of state variable must be.*Get sum=1.0 instead."
-        ):
-            metric.to("cuda")

--- a/tests/metrics/test_toolkit.py
+++ b/tests/metrics/test_toolkit.py
@@ -333,12 +333,10 @@ class MetricCollectionToolkitTest(unittest.TestCase):
         }
 
         self.assertDictEqual(
-            # pyre-ignore: Incompatible parameter type [6]: In call `unittest.case.TestCase.assertDictEqual`, for 1st positional only parameter expected `Mapping[typing.Any, object]` but got `Optional[Dict[str, Dict[str, typing.Any]]]`.
             get_synced_state_dict_collection(metric_collection),
             state_dict_collection,
         )
         self.assertDictEqual(
-            # pyre-ignore: Incompatible parameter type [6]: In call `unittest.case.TestCase.assertDictEqual`, for 1st positional only parameter expected `Mapping[typing.Any, object]` but got `Optional[Dict[str, Dict[str, typing.Any]]]`.
             get_synced_state_dict_collection(metric_collection),
             state_dict_collection,
         )

--- a/tests/metrics/window/test_auroc.py
+++ b/tests/metrics/window/test_auroc.py
@@ -76,7 +76,13 @@ class TestWindowedBinaryAUROC(MetricClassTester):
         )
         self.run_class_implementation_tests(
             metric=WindowedBinaryAUROC(max_num_samples=max_num_samples),
-            state_names={"inputs", "targets", "weights"},
+            state_names={
+                "max_num_samples",
+                "total_samples",
+                "inputs",
+                "targets",
+                "weights",
+            },
             update_kwargs={
                 "input": input,
                 "target": target,
@@ -159,7 +165,13 @@ class TestWindowedBinaryAUROC(MetricClassTester):
             metric=WindowedBinaryAUROC(
                 num_tasks=num_tasks, max_num_samples=max_num_samples
             ),
-            state_names={"inputs", "targets", "weights"},
+            state_names={
+                "max_num_samples",
+                "total_samples",
+                "inputs",
+                "targets",
+                "weights",
+            },
             update_kwargs={
                 "input": input,
                 "target": target,
@@ -213,7 +225,13 @@ class TestWindowedBinaryAUROC(MetricClassTester):
 
         self.run_class_implementation_tests(
             metric=WindowedBinaryAUROC(max_num_samples=6),
-            state_names={"inputs", "targets", "weights"},
+            state_names={
+                "max_num_samples",
+                "total_samples",
+                "inputs",
+                "targets",
+                "weights",
+            },
             update_kwargs={
                 "input": update_input,
                 "target": update_target,

--- a/tests/metrics/window/test_click_through_rate.py
+++ b/tests/metrics/window/test_click_through_rate.py
@@ -18,6 +18,8 @@ class TestClickThroughRate(MetricClassTester):
                 num_tasks=1, max_num_updates=2, enable_lifetime=True
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "click_total",
                 "weight_total",
                 "windowed_click_total",
@@ -41,6 +43,8 @@ class TestClickThroughRate(MetricClassTester):
                 num_tasks=1, max_num_updates=2, enable_lifetime=False
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "windowed_click_total",
                 "windowed_weight_total",
             },
@@ -73,6 +77,8 @@ class TestClickThroughRate(MetricClassTester):
                 num_tasks=2, max_num_updates=2, enable_lifetime=True
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "click_total",
                 "weight_total",
                 "windowed_click_total",
@@ -98,6 +104,8 @@ class TestClickThroughRate(MetricClassTester):
                 num_tasks=2, max_num_updates=2, enable_lifetime=True
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "click_total",
                 "weight_total",
                 "windowed_click_total",

--- a/tests/metrics/window/test_mean_squared_error.py
+++ b/tests/metrics/window/test_mean_squared_error.py
@@ -82,6 +82,8 @@ class TestMeanSquaredError(MetricClassTester):
         ).squeeze()
         state_names = (
             {
+                "max_num_updates",
+                "total_updates",
                 "sum_squared_error",
                 "sum_weight",
                 "windowed_sum_squared_error",
@@ -297,6 +299,8 @@ class TestMeanSquaredError(MetricClassTester):
                 multioutput=multioutput,
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "windowed_sum_squared_error",
                 "windowed_sum_weight",
             },
@@ -364,6 +368,8 @@ class TestMeanSquaredError(MetricClassTester):
                 multioutput=multioutput,
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "windowed_sum_squared_error",
                 "windowed_sum_weight",
             },

--- a/tests/metrics/window/test_weighted_calibration.py
+++ b/tests/metrics/window/test_weighted_calibration.py
@@ -19,6 +19,8 @@ class TestWindowedWeightedCalibration(MetricClassTester):
         self.run_class_implementation_tests(
             metric=WindowedWeightedCalibration(max_num_updates=2, enable_lifetime=True),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "weighted_input_sum",
                 "weighted_target_sum",
                 "windowed_weighted_input_sum",
@@ -43,6 +45,8 @@ class TestWindowedWeightedCalibration(MetricClassTester):
                 max_num_updates=2, enable_lifetime=False
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "windowed_weighted_input_sum",
                 "windowed_weighted_target_sum",
             },
@@ -87,6 +91,8 @@ class TestWindowedWeightedCalibration(MetricClassTester):
                 num_tasks=2, max_num_updates=2, enable_lifetime=True
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "weighted_input_sum",
                 "weighted_target_sum",
                 "windowed_weighted_input_sum",
@@ -119,6 +125,8 @@ class TestWindowedWeightedCalibration(MetricClassTester):
                 num_tasks=2, max_num_updates=2, enable_lifetime=False
             ),
             state_names={
+                "max_num_updates",
+                "total_updates",
                 "windowed_weighted_input_sum",
                 "windowed_weighted_target_sum",
             },

--- a/torcheval/metrics/aggregation/cat.py
+++ b/torcheval/metrics/aggregation/cat.py
@@ -60,7 +60,7 @@ class Cat(Metric[torch.Tensor]):
             dim: The dimension along which to concatenate, as in ``torch.cat()``.
         """
         super().__init__(device=device)
-        self.dim = dim
+        self._add_state("dim", dim)
         self._add_state("inputs", [])
 
     @torch.inference_mode()

--- a/torcheval/metrics/metric.py
+++ b/torcheval/metrics/metric.py
@@ -15,7 +15,7 @@ import torch
 TSelf = TypeVar("TSelf", bound="Metric")
 TComputeReturn = TypeVar("TComputeReturn")
 # pyre-ignore[33]: Flexible key data type for dictionary
-TState = Union[torch.Tensor, List[torch.Tensor], Dict[Any, torch.Tensor]]
+TState = Union[torch.Tensor, List[torch.Tensor], Dict[Any, torch.Tensor], int, float]
 
 
 class Metric(Generic[TComputeReturn], ABC):
@@ -166,6 +166,10 @@ class Metric(Generic[TComputeReturn], ABC):
                 state_dict[state_name] = {
                     key: tensor.detach().clone() for key, tensor in value.items()
                 }
+            elif isinstance(value, int):
+                state_dict[state_name] = value
+            elif isinstance(value, float):
+                state_dict[state_name] = value
         return state_dict
 
     def load_state_dict(
@@ -267,9 +271,11 @@ def _check_state_variable_type(name: str, value: Any) -> None:
             isinstance(value, dict)
             and all(isinstance(x, torch.Tensor) for x in value.values())
         )
+        and not isinstance(value, int)
+        and not isinstance(value, float)
     ):
         raise TypeError(
             "The value of state variable must be a ``torch.Tensor``, a list of ``torch.Tensor``, "
-            f"or a dictionary with ``torch.Tensor`` as values."
+            f"a dictionary with ``torch.Tensor``, int, or float as values."
             f"Get {name}={value} instead."
         )

--- a/torcheval/metrics/window/auroc.py
+++ b/torcheval/metrics/window/auroc.py
@@ -70,9 +70,9 @@ class WindowedBinaryAUROC(Metric[torch.Tensor]):
                 "`max_num_samples` value should be greater than and equal to 1, but received {max_num_samples}. "
             )
         self.num_tasks = num_tasks
-        self.max_num_samples = max_num_samples
+        self._add_state("max_num_samples", max_num_samples)
         self.next_inserted = 0
-        self.total_samples = 0
+        self._add_state("total_samples", 0)
         self._add_state(
             "inputs",
             torch.zeros(self.num_tasks, self.max_num_samples, device=self.device),

--- a/torcheval/metrics/window/click_through_rate.py
+++ b/torcheval/metrics/window/click_through_rate.py
@@ -69,10 +69,10 @@ class WindowedClickThroughRate(
                 "`max_num_updates` value should be greater than and equal to 1, but received {max_num_updates}. "
             )
         self.num_tasks = num_tasks
-        self.max_num_updates = max_num_updates
+        self._add_state("max_num_updates", max_num_updates)
         self.next_inserted = 0
         self.enable_lifetime = enable_lifetime
-        self.total_updates = 0
+        self._add_state("total_updates", 0)
         if self.enable_lifetime:
             self._add_state(
                 "click_total",

--- a/torcheval/metrics/window/mean_squared_error.py
+++ b/torcheval/metrics/window/mean_squared_error.py
@@ -88,11 +88,11 @@ class WindowedMeanSquaredError(
                 "`max_num_updates` value should be greater than and equal to 1, but received {max_num_updates}. "
             )
         self.num_tasks = num_tasks
-        self.max_num_updates = max_num_updates
+        self._add_state("max_num_updates", max_num_updates)
         self.enable_lifetime = enable_lifetime
         self.multioutput = multioutput
         self.next_inserted = 0
-        self.total_updates = 0
+        self._add_state("total_updates", 0)
 
         if self.enable_lifetime:
             self._add_state(

--- a/torcheval/metrics/window/weighted_calibration.py
+++ b/torcheval/metrics/window/weighted_calibration.py
@@ -77,10 +77,10 @@ class WindowedWeightedCalibration(
                 "`num_tasks` value should be greater than and equal to 1, but received {num_tasks}. "
             )
         self.num_tasks = num_tasks
-        self.max_num_updates = max_num_updates
+        self._add_state("max_num_updates", max_num_updates)
         self.enable_lifetime = enable_lifetime
         self.next_inserted = 0
-        self.total_updates = 0
+        self._add_state("total_updates", 0)
         if self.enable_lifetime:
             self._add_state(
                 "weighted_input_sum",

--- a/torcheval/utils/test_utils/metric_class_tester.py
+++ b/torcheval/utils/test_utils/metric_class_tester.py
@@ -370,6 +370,14 @@ def assert_result_close(
         tc.assertEqual(len(result), len(expected_result))
         for element, expected_element in zip(result, expected_result):
             assert_result_close(element, expected_element, atol, rtol)
+    elif isinstance(result, int):
+        tc.assertTrue(isinstance(expected_result, int))
+        tc.assertEqual(result, expected_result)
+    elif isinstance(result, float):
+        tc.assertTrue(isinstance(expected_result, float))
+        torch.testing.assert_close(
+            result, expected_result, atol=atol, rtol=rtol, equal_nan=True
+        )
     else:
         # add more supported type to result comparision if needed
         raise ValueError("Compute result comparision is not supported.")


### PR DESCRIPTION
Summary: using float variables can reduce latency of moving these variables onto gpu

Reviewed By: ananthsub

Differential Revision: D46861285

