### PR TITLE
optimize repacking of metrics

### DIFF
--- a/tests/metrics/test_synclib.py
+++ b/tests/metrics/test_synclib.py
@@ -1,0 +1,419 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import uuid
+
+import torch
+import torch.distributed as dist
+import torch.distributed.launcher as pet
+from pyre_extensions import none_throws
+
+from torcheval.metrics.synclib import (
+    _sync_dtype_and_shape,
+    _sync_list_length,
+    metrics_traversal_order,
+    sync_states,
+)
+from torchtnt.utils.env import init_from_env
+
+_METRIC_NAME = "tmp"
+
+
+def _get_launch_config(num_processes: int) -> pet.LaunchConfig:
+    lc = pet.LaunchConfig(
+        min_nodes=1,
+        max_nodes=1,
+        nproc_per_node=num_processes,
+        run_id=str(uuid.uuid4()),
+        rdzv_backend="c10d",
+        rdzv_endpoint="localhost:0",
+        max_restarts=0,
+        monitor_interval=1,
+    )
+    return lc
+
+
+class SynclibTest(unittest.TestCase):
+    def test_sync_list_length(self) -> None:
+        lc = _get_launch_config(num_processes=4)
+        pet.elastic_launch(lc, entrypoint=_test_sync_list_length)()
+
+    def test_sync_dtype_and_shape(self) -> None:
+        lc = _get_launch_config(num_processes=3)
+        pet.elastic_launch(lc, entrypoint=_test_sync_dtype_and_shape)()
+
+    def test_tensor_sync_states(self) -> None:
+        lc = _get_launch_config(num_processes=3)
+        pet.elastic_launch(lc, entrypoint=_test_tensor_sync_state)()
+
+    def test_tensor_list_sync_states(self) -> None:
+        lc = _get_launch_config(num_processes=3)
+        pet.elastic_launch(lc, entrypoint=_test_tensor_list_sync_state)()
+
+    def test_tensor_dict_sync_states(self) -> None:
+        lc = _get_launch_config(num_processes=2)
+        pet.elastic_launch(lc, entrypoint=_test_tensor_dict_sync_state)()
+
+    def test_complex_mixed_state_sync(self) -> None:
+        lc = _get_launch_config(num_processes=2)
+        pet.elastic_launch(lc, entrypoint=_test_complex_mixed_state)()
+
+    def test_empty_tensor_list_sync_state(self) -> None:
+        lc = _get_launch_config(num_processes=2)
+        pet.elastic_launch(lc, entrypoint=_test_empty_tensor_list_sync_state)()
+
+    def test_numeric_sync_state(self) -> None:
+        lc = _get_launch_config(num_processes=3)
+        pet.elastic_launch(lc, entrypoint=_test_numeric_sync_state)()
+
+
+def _test_sync_list_length() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        tensor_list = [torch.tensor(1).to(device) for _ in range(1)]
+    elif dist.get_rank() == 1:
+        tensor_list = []
+    elif dist.get_rank() == 2:
+        tensor_list = [torch.tensor(1).to(device) for _ in range(4)]
+    else:
+        tensor_list = [torch.tensor(1).to(device) for _ in range(3)]
+
+    length_list = _sync_list_length(tensor_list, process_group=None)
+    tc = unittest.TestCase()
+    tc.assertEqual(length_list, [1, 0, 4, 3])
+
+
+def _test_sync_dtype_and_shape() -> None:
+    device = init_from_env()
+
+    dtype = torch.float64
+    shape = torch.Size([])
+    if dist.get_rank() == 0:
+        data = [torch.tensor(val, dtype=dtype).to(device) for val in (3,)]
+    elif dist.get_rank() == 1:
+        data = [torch.tensor(val, dtype=dtype).to(device) for val in (1, 2)]
+    else:
+        data = []
+
+    if len(data) > 0:
+        res_dtype, res_shape = none_throws(
+            _sync_dtype_and_shape(data[0], process_group=None)
+        )
+    else:
+        res_dtype, res_shape = none_throws(
+            _sync_dtype_and_shape(None, process_group=None)
+        )
+
+    tc = unittest.TestCase()
+    tc.assertEqual(dtype, res_dtype)
+    tc.assertEqual(shape, res_shape)
+
+    synced_dtype = _sync_dtype_and_shape(None, process_group=None)
+    tc.assertIsNone(synced_dtype)
+
+
+def _test_tensor_sync_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": torch.tensor(11.0, device=device),
+                "num_total": torch.tensor(80.0, device=device),
+            }
+        }
+    elif dist.get_rank() == 1:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": torch.tensor(43.0, device=device),
+                "num_total": torch.tensor(50.0, device=device),
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": torch.tensor(51.0, device=device),
+                "num_total": torch.tensor(60.0, device=device),
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 3)
+    tc.assertTrue(all([len(synced_states[i]) == 1 for i in range(3)]))
+    tc.assertTrue(all([_METRIC_NAME in synced_states[i] for i in range(3)]))
+    tc.assertTrue(all([len(synced_states[i][_METRIC_NAME]) == 2 for i in range(3)]))
+    tc.assertTrue(
+        all(["num_correct" in synced_states[i][_METRIC_NAME] for i in range(3)])
+    )
+    tc.assertTrue(
+        all(["num_total" in synced_states[i][_METRIC_NAME] for i in range(3)])
+    )
+
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["num_correct"], torch.tensor(11.0, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["num_total"], torch.tensor(80.0, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["num_correct"], torch.tensor(43.0, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["num_total"], torch.tensor(50.0, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[2][_METRIC_NAME]["num_correct"], torch.tensor(51.0, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[2][_METRIC_NAME]["num_total"], torch.tensor(60.0, device=device)
+    )
+
+
+def _test_tensor_list_sync_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [
+                    torch.tensor(1, device=device),
+                    torch.tensor(3, device=device),
+                ],
+                "total": [torch.tensor(1, device=device)],
+            }
+        }
+    elif dist.get_rank() == 1:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [torch.tensor(1, device=device)],
+                "total": [torch.tensor(1, device=device)],
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [torch.tensor(1, device=device)],
+                "total": [torch.tensor(1, device=device)],
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 3)
+    tc.assertTrue(all([len(synced_states[i]) == 1 for i in range(3)]))
+    tc.assertTrue(all([_METRIC_NAME in synced_states[i] for i in range(3)]))
+    tc.assertTrue(all([len(synced_states[i][_METRIC_NAME]) == 2 for i in range(3)]))
+    tc.assertTrue(all(["seen" in synced_states[i][_METRIC_NAME] for i in range(3)]))
+    tc.assertTrue(all(["total" in synced_states[i][_METRIC_NAME] for i in range(3)]))
+
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["seen"],
+        [torch.tensor(1, device=device), torch.tensor(3, device=device)],
+    )
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["total"], [torch.tensor(1, device=device)]
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["seen"], [torch.tensor(1, device=device)]
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["total"], [torch.tensor(1, device=device)]
+    )
+    torch.testing.assert_close(
+        synced_states[2][_METRIC_NAME]["seen"], [torch.tensor(1, device=device)]
+    )
+    torch.testing.assert_close(
+        synced_states[2][_METRIC_NAME]["total"], [torch.tensor(1, device=device)]
+    )
+
+
+def _test_tensor_dict_sync_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "mapping": {
+                    "a": torch.tensor(1, device=device),
+                    "b": torch.tensor(10, device=device),
+                },
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "mapping": {
+                    "a": torch.tensor(2, device=device),
+                    "b": torch.tensor(20, device=device),
+                },
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 2)
+
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["mapping"]["a"],
+        torch.tensor(1, device=device),
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["mapping"]["a"],
+        torch.tensor(2, device=device),
+    )
+
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["mapping"]["b"],
+        torch.tensor(10, device=device),
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["mapping"]["b"],
+        torch.tensor(20, device=device),
+    )
+
+
+def _test_complex_mixed_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [
+                    torch.randn((2, 3), device=device),
+                    torch.randn((2, 3), device=device),
+                ],
+                "total": torch.tensor(1, device=device),
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [
+                    torch.randn((2, 3), device=device),
+                    torch.randn((2, 3), device=device),
+                    torch.randn((2, 3), device=device),
+                ],
+                "total": torch.tensor(2, device=device),
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 2)
+    tc.assertTrue(all([len(synced_states[i]) == 1 for i in range(2)]))
+    tc.assertTrue(all([_METRIC_NAME in synced_states[i] for i in range(2)]))
+    tc.assertTrue(all([len(synced_states[i][_METRIC_NAME]) == 2 for i in range(2)]))
+    tc.assertTrue(all(["seen" in synced_states[i][_METRIC_NAME] for i in range(2)]))
+    tc.assertTrue(all(["total" in synced_states[i][_METRIC_NAME] for i in range(2)]))
+
+    tc.assertEquals(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
+    tc.assertEquals(len(synced_states[1][_METRIC_NAME]["seen"]), 3)
+
+    torch.testing.assert_close(
+        synced_states[0][_METRIC_NAME]["total"], torch.tensor(1, device=device)
+    )
+    torch.testing.assert_close(
+        synced_states[1][_METRIC_NAME]["total"], torch.tensor(2, device=device)
+    )
+
+
+def _test_empty_tensor_list_sync_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [
+                    torch.randn((2, 3), device=device),
+                    torch.randn((2, 3), device=device),
+                ],
+                "total": [torch.tensor(1, device=device)],
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "seen": [],
+                "total": [torch.tensor(1, device=device)],
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 2)
+    tc.assertTrue(all([len(synced_states[i]) == 1 for i in range(2)]))
+    tc.assertTrue(all([_METRIC_NAME in synced_states[i] for i in range(2)]))
+    tc.assertTrue(all([len(synced_states[i][_METRIC_NAME]) == 2 for i in range(2)]))
+    tc.assertTrue(all(["seen" in synced_states[i][_METRIC_NAME] for i in range(2)]))
+    tc.assertTrue(all(["total" in synced_states[i][_METRIC_NAME] for i in range(2)]))
+
+    tc.assertEquals(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
+    tc.assertEquals(len(synced_states[1][_METRIC_NAME]["seen"]), 0)
+
+
+def _test_numeric_sync_state() -> None:
+    device = init_from_env()
+
+    if dist.get_rank() == 0:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": 11,
+                "num_total": 80,
+            }
+        }
+    elif dist.get_rank() == 1:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": 43,
+                "num_total": 50,
+            }
+        }
+    else:
+        state_data = {
+            _METRIC_NAME: {
+                "num_correct": 51.0,
+                "num_total": 60.0,
+            }
+        }
+
+    # pyre-ignore: Incompatible parameter type [6]:
+    dict_items = metrics_traversal_order(state_data)
+    synced_states = sync_states(state_data, {_METRIC_NAME: device}, dict_items)
+
+    tc = unittest.TestCase()
+    tc.assertEqual(len(synced_states), 3)
+    tc.assertTrue(all([len(synced_states[i]) == 1 for i in range(3)]))
+    tc.assertTrue(all([_METRIC_NAME in synced_states[i] for i in range(3)]))
+    tc.assertTrue(all([len(synced_states[i][_METRIC_NAME]) == 2 for i in range(3)]))
+    tc.assertTrue(
+        all(["num_correct" in synced_states[i][_METRIC_NAME] for i in range(3)])
+    )
+    tc.assertTrue(
+        all(["num_total" in synced_states[i][_METRIC_NAME] for i in range(3)])
+    )
+
+    torch.testing.assert_close(synced_states[0][_METRIC_NAME]["num_correct"], 11)
+    torch.testing.assert_close(synced_states[0][_METRIC_NAME]["num_total"], 80)
+    torch.testing.assert_close(synced_states[1][_METRIC_NAME]["num_correct"], 43)
+    torch.testing.assert_close(synced_states[1][_METRIC_NAME]["num_total"], 50)
+    torch.testing.assert_close(synced_states[2][_METRIC_NAME]["num_correct"], 51.0)
+    torch.testing.assert_close(synced_states[2][_METRIC_NAME]["num_total"], 60.0)

--- a/torcheval/metrics/synclib.py
+++ b/torcheval/metrics/synclib.py
@@ -1,0 +1,291 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This file contains functions to synchronize metric states across processes, to be called within toolkit.py
+
+The overall process goes as follows:
+
+1) Metrics are converted to their state dict representations
+2) A traversal order is established through these state dicts (by alphabetical order of keys)
+3) An empty dictionary to store states received from other processes is created (this is `gathered_states` in the code)
+4) The traversal begins, for each metric's state:
+    - validates it is one of Tensor, List[Tensor], Dict[str, Tensor], int, or float type
+    - calls the appropriate helper sync function to receive and store that state from all other processes
+5) Returns these states to toolkit
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from torch import distributed as dist
+from torcheval.metrics.metric import TState
+from torchtnt.utils.distributed import all_gather_tensors
+
+_logger: logging.Logger = logging.getLogger(__name__)
+
+
+def metrics_traversal_order(
+    state_dict: Dict[str, Dict[str, TState]]
+) -> List[Tuple[str, str]]:
+    """
+    Args:
+        state_dict: a dictionary of metric states (metric name -> metric's state dict).
+
+    Returns: a list of tuple defining how to traverse a group of metrics deterministically.
+        ie ((metric1 name, metric1 state1), (metric1 name, metric1 state2), (metric2 name, metric2 state1), ...)
+    """
+    dict_items = []
+    for outer_key in sorted(state_dict.keys()):
+        inner_dict = state_dict[outer_key]
+        for inner_key in sorted(inner_dict.keys()):
+            dict_items.append((outer_key, inner_key))
+    return dict_items
+
+
+def _get_empty_metric_state_collection(
+    metrics_traversal_order: List[Tuple[str, str]],
+) -> Dict[str, Dict[str, Any]]:
+    metric_state_collection = {}
+    for metric_name, state_name in metrics_traversal_order:
+        if metric_name not in metric_state_collection.keys():
+            metric_state_collection[metric_name] = {}
+        metric_state_collection[metric_name][state_name] = {}
+    return metric_state_collection
+
+
+def _sync_tensor_states(
+    metric_name: str,
+    state_name: str,
+    my_state_data: torch.Tensor,
+    gathered_states: List[Dict[str, Dict[str, Any]]],
+    process_group: Optional[dist.ProcessGroup],
+) -> None:
+    gathered_state_data = all_gather_tensors(my_state_data, group=process_group)
+    for i, state_tensor in enumerate(gathered_state_data):
+        gathered_states[i][metric_name][state_name] = state_tensor
+
+
+def _sync_dtype_and_shape(
+    tensor: Optional[torch.Tensor],
+    process_group: Optional[dist.ProcessGroup],
+) -> Optional[Tuple[torch.dtype, torch.Size]]:
+    my_rank = dist.get_rank(group=process_group)
+    world_size = dist.get_world_size(group=process_group)
+
+    rank_with_dtype = -1
+    if tensor is not None:
+        rank_with_dtype = my_rank  # send its rank
+
+    object_list = [None for _ in range(world_size)]
+    dist.all_gather_object(object_list, rank_with_dtype, group=process_group)
+    # pyre-ignore: Incompatible parameter type [6]
+    rank_with_dtype = max(object_list)  # choose highest rank to broadcast dtype
+
+    if rank_with_dtype == -1:
+        # all ranks have passed None for tensor
+        return None
+
+    # Broadcast the dtype from the rank that knows it to all other processes
+    if my_rank == rank_with_dtype:
+        # pyre-ignore: Undefined attribute [16]
+        object_list = [(tensor.dtype, tensor.shape)]
+    else:
+        object_list = [None]
+
+    dist.broadcast_object_list(object_list, src=rank_with_dtype, group=process_group)
+    dtype, shape = object_list[0]
+    return dtype, shape
+
+
+def _sync_list_length(
+    state_data: List[torch.Tensor], process_group: Optional[dist.ProcessGroup]
+) -> List[int]:
+    my_length = len(state_data)
+    world_size = dist.get_world_size(group=process_group)
+
+    lengths = [None for _ in range(world_size)]
+    dist.all_gather_object(lengths, my_length, group=process_group)
+
+    # pyre-ignore: Incompatible parameter type [7]
+    return lengths
+
+
+def _generate_dummy_tensor(
+    shape: torch.Size,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    return torch.empty(shape, dtype=dtype, device=device)
+
+
+def _sync_list_tensor_states(
+    metric_name: str,
+    state_name: str,
+    my_state_data: List[torch.Tensor],
+    device: torch.device,
+    gathered_states: List[Dict[str, Dict[str, Any]]],
+    process_group: Optional[dist.ProcessGroup],
+) -> None:
+    # get length of lists across all ranks
+    gathered_list_lengths = _sync_list_length(
+        my_state_data, process_group=process_group
+    )
+    if any([length == 0 for length in gathered_list_lengths]):
+        # one or more ranks has empty list, need to sync dtype and shape
+        # so it can send appropriate dummy tensor for allgather
+
+        if len(my_state_data) > 0:
+            # if at least one element, send your tensor dtype and shape
+            result = _sync_dtype_and_shape(
+                my_state_data[0], process_group=process_group
+            )
+        else:
+            # otherwise send None to indicate your list is empty
+            result = _sync_dtype_and_shape(None, process_group=process_group)
+        if result is None:
+            # all ranks state_data is empty, no need to sync
+            return
+        dtype, shape = result  # unpack results
+    else:
+        # pull dtype and ndim from local data
+        shape = my_state_data[0].shape
+        dtype = my_state_data[0].dtype
+
+    max_length = max(gathered_list_lengths)
+
+    # go through each element in list and sync the tensors
+    for i in range(max_length):
+        if i < len(my_state_data):
+            gathered_state_data = all_gather_tensors(
+                my_state_data[i], group=process_group
+            )
+        else:
+            # local rank exceeded length of its list, send dummy tensor instead
+            dummy_tensor = _generate_dummy_tensor(shape, dtype, device)
+            gathered_state_data = all_gather_tensors(dummy_tensor, group=process_group)
+
+        for rank, state_tensor in enumerate(gathered_state_data):
+            if len(gathered_states[rank][metric_name][state_name]) == 0:
+                # initialize to list
+                gathered_states[rank][metric_name][state_name] = []
+            # append the received state tensor to rank unless its list length is reached
+            if i < gathered_list_lengths[rank]:
+                gathered_states[rank][metric_name][state_name].append(state_tensor)
+
+
+def _sync_dict_tensor_states(
+    metric_name: str,
+    state_name: str,
+    my_state_data: Dict[str, torch.Tensor],
+    device: torch.device,
+    gathered_states: List[Dict[str, Dict[str, Any]]],
+    process_group: Optional[dist.ProcessGroup],
+) -> None:
+    sorted_keys = sorted(my_state_data.keys())
+    tensor_list = [my_state_data[key] for key in sorted_keys]
+    _sync_list_tensor_states(
+        metric_name, state_name, tensor_list, device, gathered_states, process_group
+    )
+    for rank in range(len(gathered_states)):
+        tensor_list = gathered_states[rank][metric_name][state_name]
+        gathered_states[rank][metric_name][state_name] = dict(
+            zip(sorted_keys, tensor_list)
+        )
+
+
+def _sync_obj_states(
+    metric_name: str,
+    state_name: str,
+    # pyre-ignore: Missing parameter annotation [2]
+    my_state_data: Any,
+    gathered_states: List[Dict[str, Dict[str, Any]]],
+    process_group: Optional[dist.ProcessGroup],
+) -> None:
+    world_size = dist.get_world_size(group=process_group)
+    gathered_obj_data = [None for _ in range(world_size)]
+    dist.all_gather_object(gathered_obj_data, my_state_data, group=process_group)
+    for i, obj in enumerate(gathered_obj_data):
+        gathered_states[i][metric_name][state_name] = obj
+
+
+def sync_states(
+    states: Dict[str, Dict[str, Any]],
+    devices: Dict[str, torch.device],
+    metrics_traversal_order: List[Tuple[str, str]],
+    process_group: Optional[dist.ProcessGroup] = None,
+) -> List[Dict[str, Dict[str, Any]]]:
+    """
+    Retrieves metric states across all ranks.
+
+    Args:
+        states: local metric state dict
+        devices: mapping from metric name to device on which metric resides
+        metrics_traversal_order: list of tuple (metric_name, state_name) defining the order of traversal through the metric state dicts
+
+    Returns:
+        Metric state dict data from all ranks.
+    """
+    gathered_states = [
+        _get_empty_metric_state_collection(
+            metrics_traversal_order=metrics_traversal_order
+        )
+        for _ in range(dist.get_world_size())
+    ]
+
+    for metric_name, state_name in metrics_traversal_order:
+        my_state_data = states[metric_name][
+            state_name
+        ]  # tensor, list, dict, int, or float
+        if isinstance(my_state_data, torch.Tensor):
+            _sync_tensor_states(
+                metric_name,
+                state_name,
+                my_state_data,
+                gathered_states,
+                process_group=process_group,
+            )
+        elif isinstance(my_state_data, list):
+            _sync_list_tensor_states(
+                metric_name,
+                state_name,
+                my_state_data,
+                devices[metric_name],
+                gathered_states,
+                process_group=process_group,
+            )
+        elif isinstance(my_state_data, dict):
+            _sync_dict_tensor_states(
+                metric_name,
+                state_name,
+                my_state_data,
+                devices[metric_name],
+                gathered_states,
+                process_group=process_group,
+            )
+        elif isinstance(my_state_data, int):
+            _sync_obj_states(
+                metric_name,
+                state_name,
+                my_state_data,
+                gathered_states,
+                process_group=process_group,
+            )
+        elif isinstance(my_state_data, float):
+            _sync_obj_states(
+                metric_name,
+                state_name,
+                my_state_data,
+                gathered_states,
+                process_group=process_group,
+            )
+        else:
+            raise RuntimeError(
+                f"Do not know how to sync state of type: {type(my_state_data)} for state {metric_name} {state_name}"
+            )
+
+    return gathered_states

--- a/torcheval/metrics/toolkit.py
+++ b/torcheval/metrics/toolkit.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import logging
 from copy import deepcopy
 from typing import (
@@ -22,13 +23,16 @@ import torch
 import torch.distributed as dist
 
 from torcheval.metrics import Metric
-from torcheval.metrics.metric import TComputeReturn
+from torcheval.metrics.metric import TComputeReturn, TState
+from torcheval.metrics.synclib import metrics_traversal_order, sync_states
 
 from torchtnt.utils import PGWrapper
 
 log: logging.Logger = logging.getLogger(__name__)
 
 _TMetrics = TypeVar("_TMetrics", bound=Iterable[Metric])
+
+_TMP: str = "tmp"
 
 
 def sync_and_compute(
@@ -352,7 +356,7 @@ def _validate_rank_and_world_size(
 
 @overload
 def _sync_metric_object(
-    metric_data: Metric,
+    local_metric_data: Metric,
     process_group: dist.ProcessGroup,
     world_size: int,
 ) -> List[Metric]:
@@ -361,33 +365,63 @@ def _sync_metric_object(
 
 @overload
 def _sync_metric_object(
-    metric_data: MutableMapping[str, Metric],
+    local_metric_data: MutableMapping[str, Metric],
     process_group: dist.ProcessGroup,
     world_size: int,
-) -> List[Dict[str, Metric]]:
+) -> List[MutableMapping[str, Metric]]:
     ...
 
 
 def _sync_metric_object(
-    metric_data: Union[Metric, MutableMapping[str, Metric]],
+    local_metric_data: Union[Metric, MutableMapping[str, Metric]],
     process_group: dist.ProcessGroup,
     world_size: int,
-) -> Union[List[Metric], List[Dict[str, Metric]]]:
+) -> Union[List[Metric], List[MutableMapping[str, Metric]]]:
 
-    # Prepare metrics in data package for merge
-    if isinstance(metric_data, Metric):
-        metric_data._prepare_for_merge_state()
+    unpack = False  # unpack the dictionary into a single metric when returned. Only used when metric_data is a metric and not a dict of metrics.
+    if isinstance(local_metric_data, Metric):
+        local_metric_data = {_TMP: local_metric_data}
+        unpack = True
+
+    # Allow metrics to run some pre-processing before syncing states
+    # for example, a common optimization is to concat tensors in a list into a single tensor
+    for m in local_metric_data.values():
+        m._prepare_for_merge_state()
+
+    # create a dict of state dicts for each metric in the collection, i.e. extract the state dicts from the Metric objects
+    metric_state_data: Dict[str, Dict[str, TState]] = {}
+    metric_to_device: Dict[str, torch.device] = {}
+    for metric_name, metric in local_metric_data.items():
+        metric_state_data[metric_name] = metric.state_dict()
+        metric_to_device[metric_name] = metric.device
+
+    metric_state_traversal_order = metrics_traversal_order(metric_state_data)
+
+    world_metric_data = sync_states(
+        metric_state_data,
+        metric_to_device,
+        metric_state_traversal_order,
+        process_group=process_group,
+    )
+
+    ##============================================================
+    ## Repack states into Metrics or Dict[str, Metric]s
+    ##============================================================
+    if unpack:
+        # if they sent in one metric, just read it from the "tmp" key and return a list of metrics.
+        gathered_data_list = []
+        for rank_data in world_metric_data:
+            gathered_data_list.append(copy.deepcopy(local_metric_data[_TMP]))
+            gathered_data_list[-1].load_state_dict(rank_data[_TMP])
     else:
-        for m in metric_data.values():
-            m._prepare_for_merge_state()
-
-    # create buffer for data to land in on all ranks
-    gathered_data_list = [None] * world_size
-
-    # sync data
-    dist.all_gather_object(gathered_data_list, metric_data, group=process_group)
-    # c10d does not have type annotations.
-    # pyre-ignore Incompatible return type [7]: Expected `Union[List[Dict[str, Metric[typing.Any]]], List[Metric[typing.Any]]]` but got `List[None]`.
+        # if they sent in a dict[str, metric] return a list of dict[str, metric] populated with the gathered state dicts.
+        gathered_data_list = []
+        for rank_data in world_metric_data:
+            rank_dict = {}
+            for metric_name in local_metric_data.keys():
+                rank_dict[metric_name] = copy.deepcopy(local_metric_data[metric_name])
+                rank_dict[metric_name].load_state_dict(rank_data[metric_name])
+            gathered_data_list.append(rank_dict)
     return gathered_data_list
 
 

--- a/torcheval/metrics/toolkit.py
+++ b/torcheval/metrics/toolkit.py
@@ -257,11 +257,12 @@ def get_synced_metric(
         world_size,
     )
 
-    return (
-        clone_metric(gathered_metric_list[0])
-        .to(metric.device)
-        .merge_state(gathered_metric_list[1:])
-    )
+    local_rank = PGWrapper(process_group).get_rank()
+    other_rank_metrics: List[Metric] = [
+        gathered_metric_list[rank] for rank in range(world_size) if rank != local_rank
+    ]
+
+    return clone_metric(metric).to(metric.device).merge_state(other_rank_metrics)
 
 
 def get_synced_metric_collection(
@@ -313,28 +314,21 @@ def get_synced_metric_collection(
         world_size,
     )
 
-    if isinstance(
-        list_of_metric_collections[0], MutableMapping
-    ):  # metric bundles are dicts.
-        synced_metric_dict: Dict[str, Metric] = {}
-        # we use rank 0 metric to clone regardless
-        rank_0_dict = list_of_metric_collections[0]
+    if isinstance(list_of_metric_collections[0], MutableMapping):
+        local_rank = dist.get_rank(process_group)
 
-        for metric_key in rank_0_dict.keys():
-            base_metric = rank_0_dict[metric_key]
+        # metric bundles are dicts.
+        synced_metric_dict: Dict[str, Metric] = {}
+
+        for metric_key in metric_collection.keys():
+            base_metric = metric_collection[metric_key]
+            base_metric = clone_metric(base_metric).to(base_metric.device)
             other_rank_metrics: List[Metric] = [
                 list_of_metric_collections[rank][metric_key]
-                for rank in range(1, world_size)
+                for rank in range(world_size)
+                if rank != local_rank
             ]
-
-            synced_metric = (
-                clone_metric(base_metric)
-                .to(base_metric.device)
-                .merge_state(other_rank_metrics)
-            )
-
-            synced_metric_dict[metric_key] = synced_metric
-
+            synced_metric_dict[metric_key] = base_metric.merge_state(other_rank_metrics)
         return synced_metric_dict
 
 
@@ -411,18 +405,26 @@ def _sync_metric_object(
         # if they sent in one metric, just read it from the "tmp" key and return a list of metrics.
         gathered_data_list = []
         for rank_data in world_metric_data:
-            gathered_data_list.append(copy.deepcopy(local_metric_data[_TMP]))
-            gathered_data_list[-1].load_state_dict(rank_data[_TMP])
+            gathered_data_list.append(_convert_to_psuedo_metric(rank_data[_TMP]))
     else:
         # if they sent in a dict[str, metric] return a list of dict[str, metric] populated with the gathered state dicts.
         gathered_data_list = []
         for rank_data in world_metric_data:
             rank_dict = {}
             for metric_name in local_metric_data.keys():
-                rank_dict[metric_name] = copy.deepcopy(local_metric_data[metric_name])
-                rank_dict[metric_name].load_state_dict(rank_data[metric_name])
+                rank_dict[metric_name] = _convert_to_psuedo_metric(
+                    rank_data[metric_name]
+                )
             gathered_data_list.append(rank_dict)
     return gathered_data_list
+
+
+# pyre-ignore: Missing return annotation [3]
+def _convert_to_psuedo_metric(metric_state_dict: Dict[str, Any]) -> Any:
+    """
+    Converts dictionary to object with attributes set according to key-value.
+    """
+    return type("", (), metric_state_dict)
 
 
 def reset_metrics(metrics: _TMetrics) -> _TMetrics:


### PR DESCRIPTION
Summary: No longer deepcopies local rank metric and load state dict to create metric object for merging; instead the state_dicts are converted to objects directly and passed to the local rank metric `merge_state`

Differential Revision: D46737574

