### PR TITLE
Set requires grad for FID metric

### DIFF
--- a/torcheval/metrics/image/fid.py
+++ b/torcheval/metrics/image/fid.py
@@ -80,6 +80,7 @@ class FrechetInceptionDistance(Metric[torch.Tensor]):
         # Set the model and put it in evaluation mode
         self.model = model.to(device)
         self.model.eval()
+        self.model.requires_grad_(False)
 
         # Initialize state variables used to compute FID
         self._add_state("real_sum", torch.zeros(feature_dim, device=device))
@@ -111,8 +112,7 @@ class FrechetInceptionDistance(Metric[torch.Tensor]):
         images = images.to(self.device)
 
         # Compute activations for images using the given model
-        with torch.no_grad():
-            activations = self.model(images)
+        activations = self.model(images)
 
         batch_size = images.shape[0]
 


### PR DESCRIPTION
Summary: As title, set requires grad for model parameters in the FID metric constructor. This takes care of one more thing callers who provide a custom module have to do

Differential Revision: D47351250

