### PR TITLE
remove TorchTNT dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 Cython>=0.28.5
 scikit-learn==0.22
 scikit-image>=0.18.3
+torchtnt>=0.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-torchtnt>=0.0.5
 typing_extensions


### PR DESCRIPTION
Summary:
remove all dependencies to TorchTNT, especially to avoid any recursive dependency issues in OSS

also copied `all_gather_tensors` from torchtnt into torcheval synclib. This function can be further optimized, since it currently all_gathers to get all tensor sizes, but this is already needed to be done in the synclib as well, so an all_gather can be saved here. Will do in future diff

Differential Revision: D48340818

