### PR TITLE
update references to torcheval tool

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,4 +113,3 @@ TorchEval API
    torcheval.metrics.rst
    torcheval.metrics.functional.rst
    torcheval.metrics.toolkit.rst
-   torcheval.tools.rst

--- a/docs/source/torcheval.tools.rst
+++ b/docs/source/torcheval.tools.rst
@@ -1,8 +1,0 @@
-.. currentmodule:: torcheval
-
-Module Tools
-=============
-
-.. automodule:: torcheval.tools
-   :members:
-   :undoc-members:


### PR DESCRIPTION
Summary: forgot to remove torcheval tool from docs and in TNT docstring from D47735567

Reviewed By: bobakfb, ananthsub

Differential Revision: D48573263

