### PR TITLE
bump to version 0.0.7

### DIFF
--- a/torcheval/version.py
+++ b/torcheval/version.py
@@ -14,4 +14,4 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__: str = "0.0.6"
+__version__: str = "0.0.7"


### PR DESCRIPTION
Summary: now that updated syncing changes have been pushed and battle tested internally, bumping version to 0.0.7 version to push new release

Differential Revision: D48612001

