### PR TITLE
use generator over list comprehension in synclib

### DIFF
--- a/torcheval/metrics/synclib.py
+++ b/torcheval/metrics/synclib.py
@@ -221,7 +221,7 @@ def _sync_list_tensor_states(
     gathered_list_lengths = _sync_list_length(
         my_state_data, process_group=process_group
     )
-    if any([length == 0 for length in gathered_list_lengths]):
+    if any((length == 0 for length in gathered_list_lengths)):
         # one or more ranks has empty list, need to sync dtype and shape
         # so it can send appropriate dummy tensor for allgather
 


### PR DESCRIPTION
Summary: Fixes the warning `[C419] Unnecessary list comprehension passed to any() prevents short-circuiting - rewrite as a generator.` on line 224

Differential Revision: D48763832

