### PR TITLE
support `rank` argument in sync_states

### DIFF
--- a/torcheval/metrics/toolkit.py
+++ b/torcheval/metrics/toolkit.py
@@ -20,6 +20,7 @@ from typing import (
 
 import torch
 import torch.distributed as dist
+from pyre_extensions import none_throws
 
 from torcheval.metrics import Metric
 from torcheval.metrics.metric import TComputeReturn, TState
@@ -438,6 +439,7 @@ def _sync_metric_object(
         metric_state_traversal_order,
         process_group=process_group,
     )
+    world_metric_data = none_throws(world_metric_data)
 
     # Repack states into Metrics or Dict[str, Metric]s
     if unpack:


### PR DESCRIPTION
Summary:
# Context
TorchEval used to support syncing states on specific ranks. When rewriting the sync logic, we removed this feature to maintain simplicity. We want to add this feature back for checkpointing flexibility purposes

# This Diff
Added support for `rank` argument for methods in synclib. Next (and final) diff will add support for `rank` argument in toolkit (so for methods like `sync_and_compute`, etc that act on the metric object)

Also refactored few lines here and there for readability

Reviewed By: galrotem

Differential Revision: D49039113


