### PR TITLE
add retrieval recall to TorchEval

### DIFF
--- a/tests/metrics/functional/ranking/test_retrieval_recall.py
+++ b/tests/metrics/functional/ranking/test_retrieval_recall.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Any, Dict
+
+import torch
+from torcheval.metrics.functional import retrieval_recall
+
+
+class TestRetrievalRecall(unittest.TestCase):
+    def test_with_example_cases_one_task(self) -> None:
+        input = torch.tensor([0.1, 0.4, 0.6, 0.2, 0.5, 0.7, 0.3])
+        target = torch.tensor([0, 0, 1, 1, 1, 0, 1])
+
+        torch.testing.assert_close(
+            retrieval_recall(
+                input,
+                target,
+            ),
+            torch.tensor(4 / 4),
+        )
+        torch.testing.assert_close(
+            retrieval_recall(
+                input,
+                target,
+                k=2,
+            ),
+            torch.tensor(1 / 4),
+        )
+        torch.testing.assert_close(
+            retrieval_recall(
+                input,
+                target,
+                k=3,
+            ),
+            torch.tensor(2 / 4),
+        )
+        torch.testing.assert_close(
+            retrieval_recall(
+                input,
+                target,
+                k=4,
+            ),
+            torch.tensor(2 / 4),
+        )
+        torch.testing.assert_close(
+            retrieval_recall(
+                input,
+                target,
+                k=5,
+            ),
+            torch.tensor(3 / 4),
+        )
+
+    def test_with_example_cases_multi_tasks_k_None(self) -> None:
+        input = torch.tensor([[0.1, 0.5, 0.9]]).repeat(7, 1)
+        target = torch.tensor(
+            [
+                [0, 0, 1],
+                [0, 1, 0],
+                [0, 1, 1],
+                [1, 0, 0],
+                [1, 0, 1],
+                [1, 1, 0],
+                [1, 1, 1],
+            ]
+        )
+        expected_rp = torch.tensor([1 / 1, 1 / 1, 2 / 2, 0 / 2, 1 / 2, 1 / 2, 2 / 3])
+        torch.testing.assert_close(
+            retrieval_recall(input, target, k=2, limit_k_to_size=False, num_tasks=7),
+            expected_rp,
+        )
+
+    def test_retrieval_recall_with_invalid_parameters(self) -> None:
+        def prec(args: Dict[str, Any]) -> None:
+            retrieval_recall(
+                input=torch.tensor([1]),
+                target=torch.tensor([1]),
+                **args,
+            )
+
+        # check validations on parameter k
+        for k in [-1, 0]:
+            with self.assertRaisesRegex(
+                ValueError, rf"k must be a positive integer, got k={k}\."
+            ):
+                prec({"k": k})
+
+        # check parameters coupling between k and limit_k_to_size
+        with self.assertRaisesRegex(
+            ValueError,
+            r"when limit_k_to_size is True, k must be a positive \(>0\) integer\.",
+        ):
+            prec({"k": None, "limit_k_to_size": True})
+
+    def test_retrieval_recall_invalid_input(self) -> None:
+        def prec(args: Dict[str, Any]) -> None:
+            retrieval_recall(
+                k=1,
+                limit_k_to_size=False,
+                **args,
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"input and target should be one dimensional tensors, got input and target dimensions=3\.",
+        ):
+            prec(
+                {
+                    "input": torch.tensor([[[1], [1], [1]]]),
+                    "target": torch.tensor([[[1], [1], [1]]]),
+                }
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"input and target should be two dimensional tensors with 3 rows, got input and target shape=torch\.Size\(\[1, 3, 1\]\)\.",
+        ):
+            prec(
+                {
+                    "input": torch.tensor([[[1], [1], [1]]]),
+                    "target": torch.tensor([[[1], [1], [1]]]),
+                    "num_tasks": 3,
+                }
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"input and target should be one dimensional tensors, got input and target dimensions=0\.",
+        ):
+            prec({"input": torch.tensor(1), "target": torch.tensor(1), "num_tasks": 1})
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"input and target must be of the same shape, got input\.shape=torch\.Size\(\[2, 2\]\) and target\.shape=torch\.Size\(\[2, 3\]\)\.",
+        ):
+            prec(
+                {
+                    "target": torch.tensor([[0, 0, 0], [0, 0, 0]]),
+                    "input": torch.tensor([[1, 2], [1, 2]]),
+                }
+            )

--- a/torcheval/metrics/__init__.py
+++ b/torcheval/metrics/__init__.py
@@ -53,6 +53,7 @@ from torcheval.metrics.ranking import (
     HitRate,
     ReciprocalRank,
     RetrievalPrecision,
+    RetrievalRecall,
     WeightedCalibration,
 )
 from torcheval.metrics.regression import MeanSquaredError, R2Score
@@ -125,6 +126,7 @@ __all__ = [
     "R2Score",
     "ReciprocalRank",
     "RetrievalPrecision",
+    "RetrievalRecall",
     "StructuralSimilarity",
     "Sum",
     "Throughput",

--- a/torcheval/metrics/functional/__init__.py
+++ b/torcheval/metrics/functional/__init__.py
@@ -46,6 +46,7 @@ from torcheval.metrics.functional.ranking import (
     num_collisions,
     reciprocal_rank,
     retrieval_precision,
+    retrieval_recall,
     weighted_calibration,
 )
 from torcheval.metrics.functional.regression import mean_squared_error, r2_score
@@ -101,6 +102,7 @@ __all__ = [
     "r2_score",
     "reciprocal_rank",
     "retrieval_precision",
+    "retrieval_recall",
     "sum",
     "throughput",
     "topk_multilabel_accuracy",

--- a/torcheval/metrics/functional/ranking/__init__.py
+++ b/torcheval/metrics/functional/ranking/__init__.py
@@ -10,6 +10,7 @@ from torcheval.metrics.functional.ranking.hit_rate import hit_rate
 from torcheval.metrics.functional.ranking.num_collisions import num_collisions
 from torcheval.metrics.functional.ranking.reciprocal_rank import reciprocal_rank
 from torcheval.metrics.functional.ranking.retrieval_precision import retrieval_precision
+from torcheval.metrics.functional.ranking.retrieval_recall import retrieval_recall
 from torcheval.metrics.functional.ranking.weighted_calibration import (
     weighted_calibration,
 )
@@ -22,5 +23,6 @@ __all__ = [
     "reciprocal_rank",
     "weighted_calibration",
     "retrieval_precision",
+    "retrieval_recall",
 ]
 __doc_name__ = "Ranking Metrics"

--- a/torcheval/metrics/functional/ranking/retrieval_recall.py
+++ b/torcheval/metrics/functional/ranking/retrieval_recall.py
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Tuple
+
+import torch
+
+
+@torch.inference_mode()
+def retrieval_recall(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    k: Optional[int] = None,
+    limit_k_to_size: bool = False,
+    num_tasks: int = 1,
+) -> torch.Tensor:
+    """
+    Retrieval Recall is a metric that measures the proportion of relevant items retrieved out of the all relevant items.
+
+    It is defined as:
+    Retrieval Recall = (Number of Relevant Items Retrieved) / (Total Number of All Relevant Items)
+    This metric is also known as Recall at k, where k is the number of elements considered as being retrieved.
+
+    Its class version is :class:`torcheval.metrics.ranking.RetrievalRecall`.
+
+    Args:
+        input (Tensor):
+            Predicted scores for each document (the higher the more relevant), with shape (num_sample,) or (num_tasks, num_samples).
+        target (Tensor):
+            0 and 1 valued Tensor of ground truth identifying relevant element, with shape (num_sample,) or (num_tasks, num_samples).
+        k (int, optional):
+            the number of elements considered as being retrieved. Only the top (sorted in decreasing order) `k` elements of `input` are considered.
+            if `k` is None, all the `input` elements are considered.
+        limit_k_to_size (bool, default value: False):
+            When set to `True`, limits `k` to be at most the length of `input`, i.e. replaces `k` by `k=min(k, len(input))`.
+            This parameter can only be set to `True` if `k` is not None.
+        num_tasks (int, default value: 1): Number of tasks that need retrieval_recall calculation.
+    Returns:
+       (Tensor):
+            - If input and target are 1D: returns a tensor of dimension 0, containing the retrieval recall value.
+            - When input and target are 2D with shape (num_tasks, num_samples): returns a tensor of shape (num_tasks,) containing the retrieval recall, computed row by row.
+
+    Examples:
+        >>> import torch
+        >>> from torcheval.metrics.functional.ranking import retrieval_recall
+
+        >>> input = torch.Tensor([0.2, 0.3, 0.5, 0.1, 0.3, 0.5, 0.2])
+        >>> target = torch.Ttensor([0, 0, 1, 1, 1, 0, 1])
+        >>> retrieval_recall(input, target)
+        torch.Tensor(1.0)
+        >>> retrieval_recall(input, target, k=2)
+        torch.Tensor(0.25)
+
+    Raises:
+        ValueError:
+            if `limit_k_to_size` is True and `k` is None.
+        ValueError:
+            if `k` is not a positive integer.
+        ValueError:
+            if input or target arguments of self._retrieval_recall_compute are Tensors with dimension 0 or > 2.
+    """
+    _retrieval_recall_param_check(k, limit_k_to_size)
+    _retrieval_recall_update_input_check(input, target, num_tasks)
+    return _retrieval_recall_compute(
+        input=input,
+        target=target,
+        k=k,
+        limit_k_to_size=limit_k_to_size,
+    )
+
+
+def _retrieval_recall_param_check(
+    k: Optional[int] = None, limit_k_to_size: bool = False
+) -> None:
+    if k is not None and k <= 0:
+        raise ValueError(f"k must be a positive integer, got k={k}.")
+
+    if limit_k_to_size and k is None:
+        raise ValueError(
+            "when limit_k_to_size is True, k must be a positive (>0) integer."
+        )
+
+
+def _retrieval_recall_update_input_check(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    num_tasks: int = 1,
+    indexes: Optional[torch.Tensor] = None,
+    num_queries: int = 1,
+) -> None:
+    if input.shape != target.shape:
+        raise ValueError(
+            f"input and target must be of the same shape, got input.shape={input.shape} and target.shape={target.shape}."
+        )
+    if num_tasks == 1:
+        if input.dim() != 1:
+            raise ValueError(
+                f"input and target should be one dimensional tensors, got input and target dimensions={input.dim()}."
+            )
+    else:
+        if input.dim() != 2 or input.shape[0] != num_tasks:
+            raise ValueError(
+                f"input and target should be two dimensional tensors with {num_tasks} rows, got input and target shape={input.shape}."
+            )
+
+
+def _retrieval_recall_compute(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    k: Optional[int] = None,
+    limit_k_to_size: bool = False,
+) -> torch.Tensor:
+    nb_relevant_items = compute_nb_relevant_items_retrieved(input, k, target)
+    return nb_relevant_items / target.sum(dim=-1)
+
+
+def compute_nb_relevant_items_retrieved(
+    input: torch.Tensor,
+    k: Optional[int],
+    target: torch.Tensor,
+) -> torch.Tensor:
+    return target.gather(dim=-1, index=get_topk(input, k)[1]).sum(dim=-1)
+
+
+def get_topk(
+    t: torch.Tensor, k: Optional[int]
+) -> Tuple[torch.Tensor, torch.LongTensor]:
+    nb_samples = t.size(-1)
+    if k is None:
+        k = nb_samples
+    # take the topk values of input. /!\ Ties are sorted in an unpredictable way.
+    return t.topk(min(k, nb_samples), dim=-1)

--- a/torcheval/metrics/ranking/__init__.py
+++ b/torcheval/metrics/ranking/__init__.py
@@ -8,6 +8,7 @@ from torcheval.metrics.ranking.click_through_rate import ClickThroughRate
 from torcheval.metrics.ranking.hit_rate import HitRate
 from torcheval.metrics.ranking.reciprocal_rank import ReciprocalRank
 from torcheval.metrics.ranking.retrieval_precision import RetrievalPrecision
+from torcheval.metrics.ranking.retrieval_recall import RetrievalRecall
 from torcheval.metrics.ranking.weighted_calibration import WeightedCalibration
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "HitRate",
     "ReciprocalRank",
     "RetrievalPrecision",
+    "RetrievalRecall",
     "WeightedCalibration",
 ]
 __doc_name__ = "Ranking Metrics"

--- a/torcheval/metrics/ranking/retrieval_recall.py
+++ b/torcheval/metrics/ranking/retrieval_recall.py
@@ -1,0 +1,190 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors[16]: Undefined attribute of metric states.
+
+from typing import Iterable, Optional, TypeVar, Union
+
+import torch
+
+from torcheval.metrics.functional.ranking.retrieval_recall import (
+    _retrieval_recall_param_check,
+    _retrieval_recall_update_input_check,
+    get_topk,
+    retrieval_recall,
+)
+from torcheval.metrics.metric import Metric
+from typing_extensions import Literal
+
+
+TRetrievalRecall = TypeVar("RetrievalRecall")
+
+
+class RetrievalRecall(Metric[torch.Tensor]):
+    """
+    Compute the retrieval recall.
+    Its functional version is :func:`torcheval.metrics.functional.retrieval_recall`.
+    (Here, `input` and `target` refer to the arguments of `update` function.)
+
+    Args:
+        k (int, optional):
+            the number of elements considered as being retrieved. Only the top (sorted in decreasing order) `k` elements of `input` are considered.
+            if `k` is None, all the `input` elements are considered.
+        limit_k_to_size (bool, default value: False):
+            When set to `True`, limits `k` to be at most the length of `input`, i.e. replaces `k` by `k=min(k, len(input))`.
+            This parameter can only be set to `True` if `k` is not None.
+        empty_target_action (str, choose among ["neg", "pos", "skip", "err"], default: "neg"):
+            Choose the behaviour of `update` function when `target` does not contain at least one positive element:
+            - when 'neg': retrieval recall is equal to 0.0,
+            - when 'pos': retrieval recall is equal to 1.0,
+            - when 'skip': retrieval recall is equal to NaN.
+            - when 'err': raise a ValueError.
+        num_queries (int, default value: 1):
+            If >1, `inputs` and `targets` can contain entries related to different queries.
+            An `indexes` tensor must be passed during updates which associates each `input` and `target` to an integer between 0 and `num_queries`-1.
+            Outputs for each query are computed independently and `.compute()` will return a tensor of shape `(num_queries,)`.
+        avg (str, choose among ["macro", "none", None], default: "None"):
+            Choose the averaging method over all queries:
+            - when "none" or None: `.compute()` returns a tensor of shape `(num_queries,)`, which ith value is equal to the retrieval recall of ith query.
+            - when "macro": `.compute()` returns the average retrieval recall over all queries.
+        device: Optional[torch.device]:
+            choose the torch device to be used.
+
+    Examples:
+        >>> import torch
+        >>> from torcheval.metrics import RetrievalRecall
+
+        >>> input = torch.tensor([0.2, 0.3, 0.5, 0.1, 0.3, 0.5, 0.2])
+        >>> target = torch.tensor([0, 0, 1, 1, 1, 0, 1])
+
+        >>> metric = RetrievalRecall(k=2)
+        >>> metric.update(input, target)
+        >>> metric.compute()
+        tensor(0.25)
+
+    Raises:
+        ValueError:
+            if `empty_target_action` is not one of "neg", "pos", "skip", "err".
+        ValueError:
+            if `limit_k_to_size` is True and `k` is None.
+        ValueError:
+            if `k` is not a positive integer.
+        ValueError:
+            if `empty_target_action` == "err" and self.update is called with a target which entries are all equal to 0.
+        ValueError:
+            if input or target arguments of self.update are Tensors with different dimensions or dimension != 1.
+        ValueError:
+            if `num_queries` > 1 and argument `indexes` of function .update() is `None`.
+    """
+
+    def __init__(
+        self: TRetrievalRecall,
+        *,
+        empty_target_action: Union[
+            Literal["neg"], Literal["pos"], Literal["skip"], Literal["err"]
+        ] = "neg",
+        k: Optional[int] = None,
+        limit_k_to_size: bool = False,
+        num_queries: int = 1,
+        avg: Optional[Union[Literal["macro"], Literal["none"]]] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        _retrieval_recall_param_check(k, limit_k_to_size)
+        super().__init__(device=device)
+        self.empty_target_action = empty_target_action
+        self.num_queries = num_queries
+        self.k = k
+        self.limit_k_to_size = limit_k_to_size
+        self.avg = avg
+        self._add_state("topk", [torch.empty(0) for _ in range(num_queries)])
+        self._add_state("target", [torch.empty(0) for _ in range(num_queries)])
+
+    @torch.inference_mode()
+    # pyre-ignore[14]: `update` overrides method defined in `Metric` inconsistently.
+    def update(
+        self: TRetrievalRecall,
+        input: torch.Tensor,
+        target: torch.Tensor,
+        indexes: Optional[torch.Tensor] = None,
+    ) -> TRetrievalRecall:
+        """
+        Update the metric state with ground truth labels and predictions.
+        """
+        _retrieval_recall_update_input_check(
+            input, target, num_queries=self.num_queries, indexes=indexes
+        )
+        if self.num_queries == 1:
+            self.update_single_query(0, input, target)
+            return self
+
+        if indexes is None:
+            raise ValueError(
+                "`indexes` must be passed during update() when num_queries > 1."
+            )
+        for i in range(self.num_queries):
+            if i in indexes:
+                self.update_single_query(i, input[indexes == i], target[indexes == i])
+
+        return self
+
+    def update_single_query(
+        self, i: int, input: torch.Tensor, target: torch.Tensor
+    ) -> None:
+        batch_preds = torch.cat([self.topk[i], input])
+        batch_targets = torch.cat([self.target[i], target])
+        preds_topk = get_topk(batch_preds, self.k)
+        self.topk[i] = preds_topk[0]
+        self.target[i] = batch_targets.gather(dim=-1, index=preds_topk[1])
+
+    @torch.inference_mode()
+    def compute(self: TRetrievalRecall) -> torch.Tensor:
+        rp = []
+        for i in range(self.num_queries):
+            if not len(self.target[i]):
+                rp.append(torch.tensor([torch.nan]))
+            elif 1 not in self.target[i]:
+                if self.empty_target_action == "pos":
+                    rp.append(torch.tensor([1.0]))
+                elif self.empty_target_action == "neg":
+                    rp.append(torch.tensor([0.0]))
+                elif self.empty_target_action == "skip":
+                    rp.append(torch.tensor([torch.nan]))
+                elif self.empty_target_action == "err":
+                    raise ValueError(
+                        f"no positive value found in target={self.target[i]}."
+                    )
+            else:
+                rp.append(
+                    retrieval_recall(
+                        self.topk[i], self.target[i], self.k, self.limit_k_to_size
+                    ).reshape(-1)
+                )
+        rp = torch.cat(rp).to(self.device)
+        if self.avg == "macro":
+            return rp.nanmean()
+        else:
+            return rp
+
+    @torch.inference_mode()
+    def merge_state(
+        self: TRetrievalRecall, metrics: Iterable[TRetrievalRecall]
+    ) -> TRetrievalRecall:
+        """
+        Merge the metric state with its counterparts from other metric instances.
+
+        Args:
+            metrics (Iterable[Metric]): metric instances whose states are to be merged.
+        """
+
+        for i in range(self.num_queries):
+            self.topk[i] = torch.cat([self.topk[i]] + [m.topk[i] for m in metrics]).to(
+                self.device
+            )
+            self.target[i] = torch.cat(
+                [self.target[i]] + [m.target[i] for m in metrics]
+            ).to(self.device)
+
+        return self


### PR DESCRIPTION
Summary: This was missing in TorchEval. We need this metrics to calculate Recall@K.

Differential Revision: D50722948


