### PR TITLE
Fix warning in aggregation.mean

### DIFF
--- a/tests/metrics/aggregation/test_mean.py
+++ b/tests/metrics/aggregation/test_mean.py
@@ -54,6 +54,10 @@ class TestMean(MetricClassTester):
         metric = Mean()
         self.assertEqual(metric.compute(), torch.tensor(0.0, dtype=torch.float64))
 
+        metric = Mean()
+        metric.update(torch.tensor([0.0, 0.0]), weight=0)
+        self.assertEqual(metric.compute(), torch.tensor(0.0, dtype=torch.float64))
+
     def test_mean_class_update_input_valid_weight(self) -> None:
         update_value = [
             torch.rand(BATCH_SIZE),


### PR DESCRIPTION
Summary:
This diff fixes the incorrect warning when running `mean.compute()` when the mean is exactly 0.

Instead of checking for the weighted sum of elements to be 0, we instead check for the total sum of weights to be zero (meaning that the average can be 0 without error, but we throw a warning when dividing by zero)

We also update the error message to reflect that the issue is no weight has been accumulated, since it is possible to call this function with only 0 weights.

Addresses: https://github.com/pytorch/torcheval/issues/185

Reviewed By: JKSenthil

Differential Revision: D50806243


