### PR TITLE
Minor doc fix: PSNR

### DIFF
--- a/torcheval/metrics/image/psnr.py
+++ b/torcheval/metrics/image/psnr.py
@@ -26,7 +26,7 @@ TPeakSignalNoiseRatio = TypeVar("TPeakSignalNoiseRatio")
 class PeakSignalNoiseRatio(Metric[torch.Tensor]):
     """
     Compute the PSNR (Peak Signal to Noise Ratio) between two images.
-    Its functional version is `torcheval.metrics.functional.psnr`
+    Its functional version is `torcheval.metrics.functional.peak_signal_noise_ratio`
 
     Args:
         data_range (float): the range of the input images. Default: None.


### PR DESCRIPTION
Summary:
correct reference to [`peak_signal_noise_ratio` functional](https://pytorch.org/torcheval/main/generated/torcheval.metrics.functional.peak_signal_noise_ratio.html) in the [`PSNR` class](https://pytorch.org/torcheval/main/generated/torcheval.metrics.PeakSignalNoiseRatio.html)



Test plan:
Is a documentation fix, does not need tests