### PR TITLE
doc: Fix Misleading Error Message for multiclass_precision

### DIFF
--- a/torcheval/metrics/functional/classification/precision.py
+++ b/torcheval/metrics/functional/classification/precision.py
@@ -160,8 +160,8 @@ def _precision_compute(
         # predictions and the ground truth.
         bad_class = torch.nonzero(torch.isnan(precision))
         logging.warning(
-            f"{bad_class} classes have zero instances in both the "
-            "predictions and the ground truth labels. Precision is still logged "
+            f"{bad_class} classes have zero instances in either the "
+            "predictions or the ground truth labels. Precision is still logged "
             "as zero."
         )
 


### PR DESCRIPTION
Old message was somewhat misleading. It implies that there are always zero instances for classes in both predictions and ground truth labels.

Summary:
To make error more clear change message from

`classes have zero instances in both the predictions and the ground truth labels. Precision is still logged as zero.`

to

`classes have zero instances in either the predictions or the ground truth labels. Precision is still logged as zero.`

Fixes #{198}
[Issue](https://github.com/pytorch/torcheval/issues/198)
