### PR TITLE
Remove `.double` from `perplexity_compute`

### DIFF
--- a/torcheval/metrics/functional/text/perplexity.py
+++ b/torcheval/metrics/functional/text/perplexity.py
@@ -114,7 +114,7 @@ def _perplexity_compute(
     num_total: torch.Tensor,
 ) -> torch.Tensor:
 
-    return torch.exp(sum_log_probs / num_total).double()
+    return torch.exp(sum_log_probs / num_total)
 
 
 def _perplexity_input_check(


### PR DESCRIPTION
Summary:
MPS requires F32 but `.double` casts the output back to F64 which causes it to fail

Example:
```
import torch
from torcheval.metrics.text import Perplexity

device = torch.device("mps")
logits = torch.Tensor([[[1, 9], [2, 3]]]).to(device)
labels = torch.Tensor([[0, 1]]).int().to(device)

perplexity = Perplexity().to(torch.float32).to(device)
perplexity.update(logits, labels)
print(perplexity.compute())
```

```
  File "/Users/petertran/torcheval/torcheval/metrics/text/perplexity.py", line 121, in compute
    return _perplexity_compute(self.sum_log_probs, self.num_total)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/petertran/torcheval/torcheval/metrics/functional/text/perplexity.py", line 117, in _perplexity_compute
    return torch.exp(sum_log_probs / num_total).double()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```
