### PR TITLE
Fix precision in calculation of FID (#192)

### DIFF
--- a/tests/metrics/image/test_fid.py
+++ b/tests/metrics/image/test_fid.py
@@ -78,7 +78,7 @@ class TestFrechetInceptionDistance(MetricClassTester):
             299,
         )
         self._test_fid(
-            imgs=imgs, feature_dim=2048, expected_result=torch.tensor(4.48304)
+            imgs=imgs, feature_dim=2048, expected_result=torch.tensor(4.58449)
         )
 
     def test_fid_random_data_custom_model(self) -> None:

--- a/torcheval/metrics/image/fid.py
+++ b/torcheval/metrics/image/fid.py
@@ -95,13 +95,19 @@ class FrechetInceptionDistance(Metric[torch.Tensor]):
         self.model.requires_grad_(False)
 
         # Initialize state variables used to compute FID
-        self._add_state("real_sum", torch.zeros(feature_dim, device=device))
         self._add_state(
-            "real_cov_sum", torch.zeros((feature_dim, feature_dim), device=device)
+            "real_sum", torch.zeros(feature_dim, device=device, dtype=torch.float64)
         )
-        self._add_state("fake_sum", torch.zeros(feature_dim, device=device))
         self._add_state(
-            "fake_cov_sum", torch.zeros((feature_dim, feature_dim), device=device)
+            "real_cov_sum",
+            torch.zeros((feature_dim, feature_dim), device=device, dtype=torch.float64),
+        )
+        self._add_state(
+            "fake_sum", torch.zeros(feature_dim, device=device, dtype=torch.float64)
+        )
+        self._add_state(
+            "fake_cov_sum",
+            torch.zeros((feature_dim, feature_dim), device=device, dtype=torch.float64),
         )
         self._add_state("num_real_images", torch.tensor(0, device=device).int())
         self._add_state("num_fake_images", torch.tensor(0, device=device).int())
@@ -200,6 +206,7 @@ class FrechetInceptionDistance(Metric[torch.Tensor]):
         fid = gaussian_frechet_distance(
             real_mean.squeeze(), real_cov, fake_mean.squeeze(), fake_cov
         )
+        fid = fid.to(torch.float32)
         return fid
 
     def _FID_parameter_check(


### PR DESCRIPTION
Summary:
The calculation of Fréchet Inception Distance requires a precision of 64 bits, to align the results with those of other libraries. 

Fixes #{192}
[Issue](https://github.com/pytorch/torcheval/issues/192)
