### PR TITLE
Fix incorrect import statement in bleu_score documentation

### DIFF
--- a/torcheval/metrics/functional/text/bleu.py
+++ b/torcheval/metrics/functional/text/bleu.py
@@ -32,7 +32,7 @@ def bleu_score(
 
         Examples:
             >>> import torch
-            >>> from torcheval.metrics.functional.text import bleu
+            >>> from torcheval.metrics.functional.text import bleu_score
             >>> candidates = ["the squirrel is eating the nut"]
             >>> references = [["a squirrel is eating a nut", "the squirrel is eating a tasty nut"]]
             >>> bleu_score(candidates, references, n_gram=4)


### PR DESCRIPTION
Summary:
Fixed incorrect import statement in BLEU score documentation. Changed from `from torcheval.metrics.functional.text import bleu` to `from from torcheval.metrics.functional.text import bleu_score` to match the actual function name.

Test plan:
- The new import statement `from torcheval.metrics.functional.text import bleu_score` works correctly
- This matches the actual function name in the implementation
- The example code now runs without import errors
