### PR TITLE
Fix metric tests

### DIFF
--- a/tests/metrics/audio/test_fad.py
+++ b/tests/metrics/audio/test_fad.py
@@ -11,6 +11,10 @@ import unittest
 import numpy as np
 import torch
 from torcheval.metrics import FrechetAudioDistance
+import pytest
+
+pytest.importorskip("torchaudio.prototype.pipelines")
+
 
 
 # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.

--- a/tests/metrics/classification/test_accuracy.py
+++ b/tests/metrics/classification/test_accuracy.py
@@ -118,10 +118,15 @@ class TestMulticlassAccuracy(MetricClassTester):
         target_flattened = target.flatten()
         accuracy_per_class = np.empty(num_classes)
         for i in range(num_classes):
-            accuracy_per_class[i] = accuracy_score(
-                target_flattened[target_flattened == i].numpy(),
-                input_flattened[target_flattened == i].numpy(),
-            )
+            mask = target_flattened == i
+            if mask.sum().item() == 0:
+                accuracy_per_class[i] = np.nan
+            else:
+                accuracy_per_class[i] = accuracy_score(
+                    target_flattened[mask].numpy(),
+                    input_flattened[mask].numpy(),
+                )
+
 
         self.run_class_implementation_tests(
             metric=MulticlassAccuracy(num_classes=num_classes, average="macro"),

--- a/tests/metrics/classification/test_auroc.py
+++ b/tests/metrics/classification/test_auroc.py
@@ -37,15 +37,16 @@ class TestBinaryAUROC(MetricClassTester):
         weight_tensors = weight.reshape(-1, 1) if weight is not None else None
 
         if compute_result is None:
-            compute_result = (
-                torch.tensor(
-                    roc_auc_score(
-                        target_tensors, input_tensors, sample_weight=weight_tensors
-                    )
-                )
+            score = (
+                roc_auc_score(target_tensors, input_tensors, sample_weight=weight_tensors)
                 if weight_tensors is not None
-                else torch.tensor(roc_auc_score(target_tensors, input_tensors))
+                else roc_auc_score(target_tensors, input_tensors)
             )
+            compute_result = torch.tensor(score, dtype=torch.float64)
+
+
+
+
         if weight is not None:
             self.run_class_implementation_tests(
                 metric=BinaryAUROC(num_tasks=num_tasks, use_fbgemm=use_fbgemm),
@@ -147,7 +148,10 @@ class TestBinaryAUROC(MetricClassTester):
                 torch.cat(update_target, dim=0),
                 torch.cat(update_input, dim=0),
                 sample_weight=torch.cat(update_weight, dim=0),
+
             ),
+                dtype=torch.float64,
+
         )
 
         self.run_class_implementation_tests(

--- a/tests/metrics/functional/classification/test_accuracy.py
+++ b/tests/metrics/functional/classification/test_accuracy.py
@@ -117,10 +117,15 @@ class TestMultiClassAccuracy(unittest.TestCase):
         target_flattened = target.flatten()
         accuracy_per_class = np.empty(num_classes)
         for i in range(num_classes):
-            accuracy_per_class[i] = accuracy_score(
-                target_flattened[target_flattened == i].numpy(),
-                input_flattened[target_flattened == i].numpy(),
-            )
+            mask = target_flattened == i
+            if mask.sum().item() == 0:
+                accuracy_per_class[i] = np.nan
+            else:
+                accuracy_per_class[i] = accuracy_score(
+                    target_flattened[mask].numpy(),
+                    input_flattened[mask].numpy(),
+                )
+
 
         torch.testing.assert_close(
             multiclass_accuracy(


### PR DESCRIPTION
Summary:
- Fix flaky MulticlassAccuracy test when a class has zero samples by explicitly handling empty classes.
- Fix the same zero-sample-class edge case in functional multiclass_accuracy tests.
- Fix BinaryAUROC test failures caused by float64 vs float32 dtype mismatches.
- Skip FrechetAudioDistance VGGish tests when torchaudio prototype features are unavailable.

Test plan:
- pytest -q torcheval/tests/metrics/classification/test_accuracy.py
- pytest -q torcheval/tests/metrics/functional/classification/test_accuracy.py
- pytest -q torcheval/tests/metrics/classification/test_auroc.py
- pytest -q torcheval/tests/metrics/audio/test_fad.py
- pytest -q torcheval/tests/metrics/functional/classification

Fixes: N/A
