### PR TITLE
Upgrade 29 packages and 2 targets to Python 3.12

### DIFF
--- a/tests/metrics/test_synclib.py
+++ b/tests/metrics/test_synclib.py
@@ -458,8 +458,8 @@ def _test_complex_mixed_state(dst_rank: int | None = None) -> None:
         tc.assertTrue(all("seen" in synced_states[i][_METRIC_NAME] for i in range(2)))
         tc.assertTrue(all("total" in synced_states[i][_METRIC_NAME] for i in range(2)))
 
-        tc.assertEquals(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
-        tc.assertEquals(len(synced_states[1][_METRIC_NAME]["seen"]), 3)
+        tc.assertEqual(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
+        tc.assertEqual(len(synced_states[1][_METRIC_NAME]["seen"]), 3)
 
         torch.testing.assert_close(
             synced_states[0][_METRIC_NAME]["total"], torch.tensor(1, device=device)
@@ -507,8 +507,8 @@ def _test_empty_tensor_list_sync_state(dst_rank: int | None = None) -> None:
         tc.assertTrue(all("seen" in synced_states[i][_METRIC_NAME] for i in range(2)))
         tc.assertTrue(all("total" in synced_states[i][_METRIC_NAME] for i in range(2)))
 
-        tc.assertEquals(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
-        tc.assertEquals(len(synced_states[1][_METRIC_NAME]["seen"]), 0)
+        tc.assertEqual(len(synced_states[0][_METRIC_NAME]["seen"]), 2)
+        tc.assertEqual(len(synced_states[1][_METRIC_NAME]["seen"]), 0)
     else:
         tc.assertIsNone(synced_states)
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tnt/pull/1042

This diff upgrades 29 packages 2 targets to Python 3.12, and was generated using pyctl upgrademate assistant.

It also contains some manual fixes applied on top because of a few API changes between Python 3.10 -> Python 3.12

Differential Revision: D91804766


