### PR TITLE
auroc.py: pass float32 weights to fbgemm batch_auc kernel

### DIFF
--- a/torcheval/metrics/functional/classification/auroc.py
+++ b/torcheval/metrics/functional/classification/auroc.py
@@ -161,13 +161,17 @@ def _binary_auroc_compute(
 ) -> torch.Tensor:
     if use_fbgemm:
         assert input.is_cuda and target.is_cuda, "Tensors have to be on GPU"
-        # auroc does not have weight
-        weight = torch.ones_like(input, dtype=torch.double)
+        # auroc does not have weight. The fbgemm ``batch_auc`` kernel dispatches
+        # the weight tensor over float32/float16 only, so a double weight raises
+        # `"auc_wrapper_3" not implemented for 'Double'`.
+        weight = torch.ones_like(input, dtype=torch.float)
         num_tasks = 1 if len(input.shape) == 1 else input.shape[0]
         # FBGEMM AUC is an approximation of AUC. It does not mask data in case
         # that input values are redundant. For the highly redundant input case,
         # FBGEMM AUC can give a significantly different result
         auroc = fbgemm_gpu.metrics.auc(num_tasks, input, target, weight)
+        # Match the double dtype returned by the non-fbgemm path.
+        auroc = auroc.double()
         if num_tasks == 1:
             return auroc[0]
         else:


### PR DESCRIPTION
Summary:
## Goal
Make `binary_auroc(..., use_fbgemm=True)` work on GPU: it previously always failed with `NotImplementedError: "auc_wrapper_3" not implemented for 'Double'`.

## Background
- The fbgemm `batch_auc` CUDA kernel dispatches its `weights` argument over float32/float16 only (`FBGEMM_DISPATCH_FLOAT_AND_HALF`), but `_binary_auroc_compute` built the weight tensor as `torch.double`.
- This never surfaced in CI: `test_auroc_fbgemm` is guarded by `skipUnless(torch.cuda.is_available())` and only ran on GPU-less hosts, where it skipped.

## What it changes
- Build the fbgemm weight tensor as `torch.float` so the kernel dispatch succeeds.
- Cast the fbgemm result back to `double` so `binary_auroc` returns the same dtype regardless of `use_fbgemm`, matching the non-fbgemm path and the float64 `sklearn.roc_auc_score` reference the test compares against.

Reviewed By: twmoveon

Differential Revision: D113702251


